### PR TITLE
Add makefile to improve building flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,6 @@ build-asgard:
 build-bifrost:
 	cargo build -p node-cli --locked --no-default-features --features "cli with-bifrost-runtime"
 
-.PHONY: build-rococo
-build-rococo:
-	cargo build -p node-cli --locked --no-default-features --features "cli with-rococo-runtime"
-
 .PHONY: build-all
 build-all:
 	cargo build -p node-cli --locked --no-default-features --features "cli with-all-runtime"
@@ -30,10 +26,6 @@ build-asgard-release:
 build-bifrost-release:
 	cargo build -p node-cli --locked --no-default-features --features "cli with-bifrost-runtime" --release
 
-.PHONY: build-rococo-release
-build-rococo-release:
-	cargo build -p node-cli --locked --no-default-features --features "cli with-rococo-runtime" --release
-
 .PHONY: build-all-release
 build-all-release:
 	cargo build -p node-cli --locked --no-default-features --features "cli with-all-runtime" --release
@@ -45,10 +37,6 @@ check-asgard:
 .PHONY: check-bifrost
 check-bifrost:
 	cargo check -p node-cli --locked --no-default-features --features "cli with-bifrost-runtime"
-
-.PHONY: check-rococo
-check-rococo:
-	cargo check -p node-cli --locked --no-default-features --features "cli with-rococo-runtime"
 
 .PHONY: check-all
 check-all:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,65 @@
+.PHONY: init
+init:
+	./scripts/init.sh
+
+# Build Debug
+
+.PHONY: build-asgard
+build-asgard:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-asgard-runtime"
+
+.PHONY: build-bifrost
+build-bifrost:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-bifrost-runtime"
+
+.PHONY: build-rococo
+build-rococo:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-rococo-runtime"
+
+.PHONY: build-all
+build-all:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-all-runtime"
+
+# Build Release
+
+.PHONY: build-asgard-release
+build-asgard-release:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-asgard-runtime" --release
+
+.PHONY: build-bifrost-release
+build-bifrost-release:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-bifrost-runtime" --release
+
+.PHONY: build-rococo-release
+build-rococo-release:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-rococo-runtime" --release
+
+.PHONY: build-all-release
+build-all-release:
+	cargo build -p node-cli --locked --no-default-features --features "cli with-all-runtime" --release
+
+.PHONY: check-asgard
+check-asgard:
+	cargo check -p node-cli --locked --no-default-features --features "cli with-asgard-runtime"
+
+.PHONY: check-bifrost
+check-bifrost:
+	cargo check -p node-cli --locked --no-default-features --features "cli with-bifrost-runtime"
+
+.PHONY: check-rococo
+check-rococo:
+	cargo check -p node-cli --locked --no-default-features --features "cli with-rococo-runtime"
+
+.PHONY: check-all
+check-all:
+	cargo check -p node-cli --locked --no-default-features --features "cli with-all-runtime"
+
+.PHONY: check-tests
+check-tests:
+	cargo check --no-default-features --features "with-all-runtime" --tests
+
+.PHONY: clean
+clean:
+	cargo clean
+
+# TODO: Copy genesis_config JSON files to target directory


### PR DESCRIPTION
- Only build node with asgard-runtime

```bash
# debug
make build-asgard

# release
make build-asgard-release
```

- Only build node with bifrost-runtime

```bash
# debug
make build-bifrost

# release
make build-bifrost-release
```

- Build node with all(asgard, bifrost)-runtime

```bash
# debug
make build-all

# release
make build-all-release
```

- Check code

```bash
# Check code only with asgard-runtime
make check-asgard

# Check code only with bifrost-runtime
make check-bifrost

# Check code with all-runtime
make check-all
```

- Check tests

```bash
make check-tests
```

- Clean the builds

```bash
make clean
```

- Init & Check Rust Environment

```bash
make init
```