### PR TITLE
Salp Revamp companion for dmp transfer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4858,10 +4858,8 @@ dependencies = [
 [[package]]
 name = "node-inspect"
 version = "0.8.0"
-source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.8#1b758b2a8d151d97d2242260c465b6df9cb8a7a4"
 dependencies = [
  "derive_more",
- "log",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-api",
@@ -4875,8 +4873,10 @@ dependencies = [
 [[package]]
 name = "node-inspect"
 version = "0.8.0"
+source = "git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.8#1b758b2a8d151d97d2242260c465b6df9cb8a7a4"
 dependencies = [
  "derive_more",
+ "log",
  "parity-scale-codec",
  "sc-cli",
  "sc-client-api",

--- a/node/primitives/src/lib.rs
+++ b/node/primitives/src/lib.rs
@@ -30,11 +30,13 @@ mod bridge;
 mod currency;
 mod tests;
 pub mod traits;
+mod xcm;
 
 pub use crate::{
 	bridge::*,
 	currency::{CurrencyId, TokenSymbol},
 	traits::*,
+	xcm::*,
 };
 
 /// An index to a block.

--- a/node/primitives/src/xcm.rs
+++ b/node/primitives/src/xcm.rs
@@ -1,3 +1,21 @@
+// This file is part of Bifrost.
+
+// Copyright (C) 2019-2021 Liebi Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
 use codec::{Decode, Encode};
 use sp_std::prelude::*;
 

--- a/node/primitives/src/xcm.rs
+++ b/node/primitives/src/xcm.rs
@@ -1,0 +1,24 @@
+use codec::{Decode, Encode};
+use sp_std::prelude::*;
+
+/// The type used to represent the xcmp transfer direction
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Encode, Decode)]
+pub enum TransferOriginType {
+	FromSelf = 0,
+	FromRelayChain = 1,
+	FromSiblingParaChain = 2,
+}
+
+pub struct XcmBaseWeight(u64);
+
+impl From<u64> for XcmBaseWeight {
+	fn from(u: u64) -> Self {
+		XcmBaseWeight(u)
+	}
+}
+
+impl From<XcmBaseWeight> for u64 {
+	fn from(x: XcmBaseWeight) -> Self {
+		x.0.into()
+	}
+}

--- a/pallets/salp/src/mock.rs
+++ b/pallets/salp/src/mock.rs
@@ -19,7 +19,7 @@
 // Ensure we're `no_std` when compiling for Wasm.
 
 use frame_support::{construct_runtime, parameter_types, traits::GenesisBuild, PalletId};
-use node_primitives::{Amount, Balance, CurrencyId, TokenSymbol};
+use node_primitives::{Amount, Balance, CurrencyId, TokenSymbol, TransferOriginType};
 use sp_arithmetic::Percent;
 use sp_core::H256;
 use sp_runtime::{
@@ -168,6 +168,7 @@ parameter_types! {
 	pub const ReleaseCycle: BlockNumber = 1 * DAYS;
 	pub const ReleaseRatio: Percent = Percent::from_percent(50);
 	pub const DepositTokenType: CurrencyId = CurrencyId::Token(TokenSymbol::ASG);
+	pub const XcmTransferOrigin: TransferOriginType = TransferOriginType::FromSelf;
 }
 
 parameter_types! {
@@ -193,6 +194,7 @@ impl salp::Config for Test {
 	type SlotLength = SlotLength;
 	type SubmissionDeposit = SubmissionDeposit;
 	type VSBondValidPeriod = VSBondValidPeriod;
+	type XcmTransferOrigin = XcmTransferOrigin;
 	type WeightInfo = salp::TestWeightInfo;
 }
 
@@ -203,7 +205,7 @@ pub(crate) static mut MOCK_XCM_RESULT: (bool, bool) = (true, true);
 pub struct MockXcmExecutor;
 
 impl BifrostXcmExecutor for MockXcmExecutor {
-	fn ump_transact(_origin: MultiLocation, _call: DoubleEncoded<()>) -> XcmResult {
+	fn ump_transact(_origin: MultiLocation, _call: DoubleEncoded<()>, _relayer: bool) -> XcmResult {
 		let result = unsafe { MOCK_XCM_RESULT.0 };
 
 		match result {
@@ -229,12 +231,16 @@ impl BifrostXcmExecutor for MockXcmExecutor {
 
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
 	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
+	let initial_balance = 100000 as u128;
 
 	orml_tokens::GenesisConfig::<Test> {
 		balances: vec![
-			(ALICE, NativeCurrencyId::get(), 100),
-			(BRUCE, NativeCurrencyId::get(), 100),
-			(CATHI, NativeCurrencyId::get(), 100),
+			(ALICE, NativeCurrencyId::get(), initial_balance),
+			(ALICE, RelayCurrencyId::get(), initial_balance),
+			(BRUCE, NativeCurrencyId::get(), initial_balance),
+			(BRUCE, RelayCurrencyId::get(), initial_balance),
+			(CATHI, NativeCurrencyId::get(), initial_balance),
+			(CATHI, RelayCurrencyId::get(), initial_balance),
 		],
 	}
 	.assimilate_storage(&mut t)

--- a/runtime/asgard/src/constants.rs
+++ b/runtime/asgard/src/constants.rs
@@ -28,6 +28,7 @@ pub mod currency {
 	pub const MILLICENTS: Balance = CENTS / 1_000;
 	pub const MILLIBNC: Balance = 1_000_000_000;
 	pub const MICROBNC: Balance = 1_000_000;
+	pub const XCM_WEIGHT: u64 = 1_000_000_000;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
 		items as Balance * 15 * CENTS + (bytes as Balance) * 6 * CENTS

--- a/runtime/asgard/src/lib.rs
+++ b/runtime/asgard/src/lib.rs
@@ -75,7 +75,9 @@ use bifrost_runtime_common::xcm_impl::{
 use codec::{Decode, Encode};
 use constants::{currency::*, time::*};
 use cumulus_primitives_core::ParaId as CumulusParaId;
-use node_primitives::{Amount, CurrencyId, Moment, Nonce, TokenSymbol};
+use node_primitives::{
+	Amount, CurrencyId, Moment, Nonce, TokenSymbol, TransferOriginType, XcmBaseWeight,
+};
 // orml imports
 use orml_currencies::BasicCurrencyAdapter;
 use orml_traits::MultiCurrency;
@@ -751,8 +753,7 @@ pub type BifrostAssetTransactor = BifrostCurrencyAdapter<
 
 pub struct XcmConfig;
 impl Config for XcmConfig {
-	// How to withdraw and deposit an asset.(upgrade to BifrostAssetTransactor later)
-	type AssetTransactor = LocalAssetTransactor;
+	type AssetTransactor = BifrostAssetTransactor;
 	type Barrier = Barrier;
 	type Call = Call;
 	type IsReserve = BifrostFilteredAssets;
@@ -940,11 +941,13 @@ parameter_types! {
 	pub const LeasePeriod: BlockNumber = KUSAMA_LEASE_PERIOD;
 	pub const ReleaseRatio: Percent = Percent::from_percent(50);
 	pub const SlotLength: BlockNumber = 8u32 as BlockNumber;
+	pub const XcmTransferOrigin: TransferOriginType = TransferOriginType::FromRelayChain;
+	pub XcmWeight: XcmBaseWeight = XCM_WEIGHT.into();
 }
 
 impl bifrost_salp::Config for Runtime {
 	type BancorPool = Bancor;
-	type BifrostXcmExecutor = BifrostXcmAdaptor<XcmRouter>;
+	type BifrostXcmExecutor = BifrostXcmAdaptor<XcmRouter, XcmWeight>;
 	type DepositToken = NativeCurrencyId;
 	type Event = Event;
 	type ExecuteXcmOrigin = EnsureXcmOrigin<Origin, LocalOriginToLocation>;
@@ -959,6 +962,7 @@ impl bifrost_salp::Config for Runtime {
 	type SlotLength = SlotLength;
 	type SubmissionDeposit = SubmissionDeposit;
 	type VSBondValidPeriod = VSBondValidPeriod;
+	type XcmTransferOrigin = XcmTransferOrigin;
 	type WeightInfo = weights::pallet_salp::WeightInfo<Runtime>; // bifrost_salp::TestWeightInfo;
 }
 

--- a/xcm-support/src/traits.rs
+++ b/xcm-support/src/traits.rs
@@ -43,7 +43,7 @@ pub trait HandleXcmpMessage {
 
 /// Bifrost Xcm Executor
 pub trait BifrostXcmExecutor {
-	fn ump_transact(origin: MultiLocation, call: DoubleEncoded<()>) -> XcmResult;
+	fn ump_transact(origin: MultiLocation, call: DoubleEncoded<()>, relay: bool) -> XcmResult;
 
 	fn ump_transfer_asset(
 		origin: MultiLocation,


### PR DESCRIPTION
  After this [discussion](https://github.com/paritytech/polkadot/issues/3500) with parity team seems the previous hack to allow remote transfer from parachain directly is not doerable.  Instead we need to change the xcmp transfer origin from relaychain side. The pr is mainly about xcmp flow revamp based on this and also with some transaction fee change.  

 In new salp flow a xcmp asset transfer from relaychain as following is required before contribute 
  
![image (9)](https://user-images.githubusercontent.com/4383920/126924169-bad79bee-0703-4ead-93a8-847a2808331e.png)
![image](https://user-images.githubusercontent.com/4383920/126924173-6148f1b8-ac01-49af-8c63-5611b5491e67.png)
 
 
