### PR TITLE
Build wasm script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ node_modules
 yarn.lock
 *.log
 output
+deploy

--- a/.maintain/build-image.sh
+++ b/.maintain/build-image.sh
@@ -8,7 +8,7 @@ if [[ -z "$1" ]] ; then
 fi
 
 eval $(ssh-agent)
-ssh-add ~/.ssh/bifrost_id_rsa
+ssh-add ~/.ssh/github_actions
 DOCKER_BUILDKIT=1 docker build --ssh default -t "$NODE_NAME:$VERSION" .
 docker push "$NODE_NAME:$VERSION"
 docker push $NODE_NAME:latest

--- a/.maintain/build-wasm.sh
+++ b/.maintain/build-wasm.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+set -xe
+
+RUSTC_VERSION="1.53.0"
+EXTRA_ARGS='--json'
+BIN_PATH=$(dirname $(readlink -f $0))
+WORK_PATH=${BIN_PATH}/..
+eval $(ssh-agent)
+ssh-add ~/.ssh/github_actions
+
+RUNTIME=$1
+
+docker run --rm -it \
+  -e PACKAGE=$RUNTIME-runtime \
+  -e VERBOSE=1 \
+  -e CARGO_TERM_COLOR=always \
+  -e SSH_AUTH_SOCK=/ssh-agent \
+  -v $(readlink -f $SSH_AUTH_SOCK):/ssh-agent \
+  -v ${TMPDIR}/cargo:/cargo-home \
+  -v ${WORK_PATH}:/build \
+  paritytech/srtool:${RUSTC_VERSION} build ${EXTRA_ARGS}
+
+mkdir -p ${WORK_PATH}/deploy/wasm
+cp ${WORK_PATH}/runtime/$RUNTIME/target/srtool/release/wbuild/$RUNTIME-runtime/${RUNTIME}_runtime.compact.wasm \
+${WORK_PATH}/deploy/wasm

--- a/Makefile
+++ b/Makefile
@@ -93,3 +93,15 @@ run-dev:
 .PHONY: run-dev-manual-seal
 run-dev-manual-seal:
 	RUST_LOG=debug cargo run -p node-cli --locked --features "with-dev-runtime" -- --tmp --dev --sealing instant
+
+.PHONY: build-docker-image
+build-docker-image:
+	.maintain/build-image.sh
+
+.PHONY: build-bifrost-wasm
+build-bifrost-wasm:
+	.maintain/build-wasm.sh bifrost
+
+.PHONY: build-asgard-wasm
+build-asgard-wasm:
+	.maintain/build-wasm.sh asgard


### PR DESCRIPTION
now just build wasm manually with srtool, we may integrated with some ci flow later so to automatic publish wasm and docker image when release, take acala as reference
https://github.com/AcalaNetwork/Acala/releases/tag/1.2.2