### PR TITLE
Try runtime

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -38,7 +38,6 @@ jobs:
       - name: Test All
         run: |
           make test-all
-          make test-benchmarking
       - name: Inform buddies online
         uses: 8398a7/action-slack@v3
         if: always() && (github.event_name == 'pull_request' && github.event.pull_request.draft == false)

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ yarn.lock
 *.log
 output
 deploy
+snapshot.bin
+*.wasm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal 0.3.2",
  "log",
  "max-encoded-len",
@@ -744,6 +745,8 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
+ "log",
  "node-primitives",
  "pallet-aura",
  "pallet-authorship",
@@ -2142,6 +2145,7 @@ dependencies = [
  "frame-support",
  "frame-system",
  "frame-system-rpc-runtime-api",
+ "frame-try-runtime",
  "hex-literal 0.3.2",
  "log",
  "max-encoded-len",
@@ -4927,6 +4931,7 @@ dependencies = [
  "cumulus-client-service",
  "cumulus-primitives-core",
  "frame-benchmarking-cli",
+ "frame-try-runtime",
  "log",
  "node-inspect 0.8.0 (git+https://github.com/paritytech/substrate?branch=polkadot-v0.9.8)",
  "node-primitives",
@@ -4942,6 +4947,7 @@ dependencies = [
  "sp-runtime",
  "structopt",
  "substrate-build-script-utils",
+ "try-runtime-cli",
 ]
 
 [[package]]
@@ -5072,6 +5078,7 @@ dependencies = [
  "sp-trie",
  "substrate-frame-rpc-system",
  "substrate-prometheus-endpoint",
+ "try-runtime-cli",
  "zenlink-protocol-runtime-api",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,8 @@ incremental = true
 node-inspect = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
+try-runtime-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
+frame-try-runtime = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 frame-executive = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 frame-metadata = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }
 frame-support = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.8" }

--- a/Makefile
+++ b/Makefile
@@ -117,3 +117,11 @@ build-bifrost-wasm:
 .PHONY: build-asgard-wasm
 build-asgard-wasm:
 	.maintain/build-wasm.sh asgard
+
+.PHONY: try-bifrost-runtime-upgrade
+try-bifrost-runtime-upgrade:
+	./scripts/try-runtime.sh bifrost
+
+.PHONY: try-asgard-runtime-upgrade
+try-asgard-runtime-upgrade:
+	./scripts/try-runtime.sh asgard

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ curl https://sh.rustup.rs -sSf | sh
 make init
 ```
 
+## Build binary
+
+```bash
+make build-all-release
+```
+
 ## Testing
 
 ```bash
@@ -49,10 +55,12 @@ if runtime logic change we may do the benchmarking to regenerate WeightInfo for 
 make run-benchmarking
 ```
 
-## Build binary
+## Testing runtime migration
+
+If modify the storage, should test the data migration before production upgrade.
 
 ```bash
-make build-all-release
+make try-bifrost-runtime-upgrade
 ```
 
 ## Run development chain

--- a/node/cli/Cargo.toml
+++ b/node/cli/Cargo.toml
@@ -35,6 +35,8 @@ node-primitives = { path = "../primitives" }
 
 # CLI-specific dependencies
 sc-cli = { version = "0.9.0", optional = true }
+try-runtime-cli = { version = "0.9.0", optional = true }
+frame-try-runtime = { version = "0.9.0", optional = true  }
 frame-benchmarking-cli = { version = "3.0.0", optional = true }
 node-inspect = { version = "0.8.0", optional = true }
 
@@ -58,6 +60,7 @@ cli = [
 	"node-inspect",
 	"sc-cli",
 	"frame-benchmarking-cli",
+	'try-runtime-cli',
 	"sc-service",
 	"structopt",
 	"substrate-build-script-utils",
@@ -75,4 +78,8 @@ with-dev-runtime = [
 with-all-runtime = [
 	"with-asgard-runtime",
 	"with-bifrost-runtime",
+]
+try-runtime = [
+	"node-service/try-runtime",
+	"try-runtime-cli",
 ]

--- a/node/cli/src/cli.rs
+++ b/node/cli/src/cli.rs
@@ -38,6 +38,11 @@ pub enum Subcommand {
 	#[structopt(name = "benchmark", about = "Benchmark runtime pallets.")]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
 
+	/// Try some experimental command on the runtime. This includes migration and runtime-upgrade
+	/// testing.
+	#[cfg(feature = "try-runtime")]
+	TryRuntime(try_runtime_cli::TryRuntimeCmd),
+
 	/// Verify a signature for a message, provided on STDIN, with a given (public or secret) key.
 	Verify(VerifyCmd),
 

--- a/node/service/Cargo.toml
+++ b/node/service/Cargo.toml
@@ -50,7 +50,7 @@ pallet-transaction-payment-rpc-runtime-api = { version = "3.0.0" }
 frame-system-rpc-runtime-api = { version = "3.0.0" }
 substrate-prometheus-endpoint = { version = "0.9.0" }
 substrate-frame-rpc-system = { version = "3.0.0" }
-
+try-runtime-cli = { version = "0.9.0", optional = true }
 # Cumulus dependencies
 cumulus-client-consensus-aura = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.8" }
 cumulus-client-consensus-common = { git = "https://github.com/paritytech/cumulus", branch = "polkadot-v0.9.8" }
@@ -107,5 +107,9 @@ with-dev-runtime = [
 with-all-runtime = [
 	"with-asgard-runtime",
 	"with-bifrost-runtime",
+]
+try-runtime = [
+	"asgard-runtime/try-runtime",
+	"bifrost-runtime/try-runtime",
 ]
 

--- a/node/service/src/lib.rs
+++ b/node/service/src/lib.rs
@@ -61,3 +61,10 @@ impl IdentifyVariant for Box<dyn sc_service::ChainSpec> {
 		self.id().starts_with("asgard-dev") || self.id().starts_with("dev")
 	}
 }
+
+pub const BIFROST_RUNTIME_NOT_AVAILABLE: &str =
+	"Bifrost runtime is not available. Please compile the node with `--features with-bifrost-runtime` to enable it.";
+pub const ASGARD_RUNTIME_NOT_AVAILABLE: &str =
+	"Asgard runtime is not available. Please compile the node with `--features with-asgard-runtime` to enable it.";
+pub const DEV_RUNTIME_NOT_AVAILABLE: &str =
+	"Dev runtime is not available. Please compile the node with `--features with-dev-runtime` to enable it.";

--- a/pallets/salp/src/lib.rs
+++ b/pallets/salp/src/lib.rs
@@ -19,6 +19,12 @@
 // Ensure we're `no_std` when compiling for Wasm.
 #![cfg_attr(not(feature = "std"), no_std)]
 
+pub mod migration {
+	pub fn migrate() {
+		log::info!("salp migration...");
+	}
+}
+
 #[cfg(feature = "runtime-benchmarks")]
 pub mod benchmarking;
 #[cfg(test)]

--- a/runtime/asgard/Cargo.toml
+++ b/runtime/asgard/Cargo.toml
@@ -30,6 +30,7 @@ sp-arithmetic = { version = "3.0.0", default-features = false }
 
 # frame dependencies
 frame-benchmarking = { version = "3.0.0", default-features = false, optional = true }
+frame-try-runtime = { version = "0.9.0", default-features = false, optional = true  }
 frame-executive = { version = "3.0.0", default-features = false }
 frame-support = { version = "3.0.0", default-features = false }
 frame-system = { version = "3.0.0", default-features = false }
@@ -108,6 +109,7 @@ std = [
 	"codec/std",
 	"log/std",
 	"frame-benchmarking/std",
+	"frame-try-runtime/std",
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
@@ -189,4 +191,11 @@ runtime-benchmarks = [
 	"bifrost-flexible-fee/runtime-benchmarks",
 	"bifrost-vtoken-mint/runtime-benchmarks",
 	"bifrost-minter-reward/runtime-benchmarks",
+]
+
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-vesting/try-runtime",
 ]

--- a/runtime/bifrost/Cargo.toml
+++ b/runtime/bifrost/Cargo.toml
@@ -8,7 +8,7 @@ build = "build.rs"
 [dependencies]
 # third-party dependencies
 codec = { package = "parity-scale-codec", version = "2.0.0", default-features = false, features = ["derive", "max-encoded-len"] }
-
+log = { version = "0.4.14", default-features = false }
 # primitives
 node-primitives = { default-features = false, path = "../../node/primitives" }
 sp-block-builder = { default-features = false, version = "3.0.0"}
@@ -25,6 +25,7 @@ sp-consensus-aura = { version = "0.9.0",  default-features = false }
 
 # frame dependencies
 frame-benchmarking = { version = "3.0.0", default-features = false, optional = true }
+frame-try-runtime = { version = "0.9.0", default-features = false, optional = true  }
 frame-executive = { version = "3.0.0", default-features = false }
 frame-support = { version = "3.0.0", default-features = false }
 frame-system = { version = "3.0.0", default-features = false }
@@ -74,7 +75,9 @@ default = ["std"]
 with-tracing = [ "frame-executive/with-tracing" ]
 std = [
 	"codec/std",
+	"log/std",
 	"frame-executive/std",
+	"frame-try-runtime/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
 	"frame-system/std",
@@ -124,4 +127,11 @@ runtime-benchmarks = [
 	"sp-runtime/runtime-benchmarks",
 	"xcm-builder/runtime-benchmarks",
 	"pallet-xcm/runtime-benchmarks",
+]
+
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-vesting/try-runtime",
 ]

--- a/runtime/bifrost/src/lib.rs
+++ b/runtime/bifrost/src/lib.rs
@@ -59,6 +59,7 @@ use sp_version::RuntimeVersion;
 /// Constant values used within the runtime.
 pub mod constants;
 use constants::{currency::*, time::*};
+use frame_support::traits::OnRuntimeUpgrade;
 use frame_system::EnsureRoot;
 use node_primitives::{Moment, Nonce};
 use pallet_xcm::XcmPassthrough;
@@ -598,6 +599,7 @@ pub type Executive = frame_executive::Executive<
 	frame_system::ChainContext<Runtime>,
 	Runtime,
 	AllPallets,
+	CustomOnRuntimeUpgrade,
 >;
 
 impl_runtime_apis! {
@@ -702,6 +704,34 @@ impl_runtime_apis! {
 		fn authorities() -> Vec<AuraId> {
 			Aura::authorities()
 		}
+	}
+
+	#[cfg(feature = "try-runtime")]
+	impl frame_try_runtime::TryRuntime<Block> for Runtime {
+		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
+			log::info!("try-runtime::on_runtime_upgrade bifrost.");
+			let weight = Executive::try_runtime_upgrade()?;
+			Ok((weight, RuntimeBlockWeights::get().max_block))
+		}
+	}
+}
+
+pub struct CustomOnRuntimeUpgrade;
+impl OnRuntimeUpgrade for CustomOnRuntimeUpgrade {
+	#[cfg(feature = "try-runtime")]
+	fn pre_upgrade() -> Result<(), &'static str> {
+		#[allow(unused_imports)]
+		use frame_support::{migration, Identity};
+
+		log::info!("Bifrost `pre_upgrade`...");
+
+		Ok(())
+	}
+
+	#[cfg(feature = "try-runtime")]
+	fn on_runtime_upgrade() -> Weight {
+		log::info!("Bifrost `on_runtime_upgrade`...");
+		RuntimeBlockWeights::get().max_block
 	}
 }
 

--- a/runtime/dev/Cargo.toml
+++ b/runtime/dev/Cargo.toml
@@ -30,6 +30,7 @@ sp-arithmetic = { version = "3.0.0", default-features = false }
 
 # frame dependencies
 frame-benchmarking = { version = "3.0.0", default-features = false, optional = true }
+frame-try-runtime = { version = "0.9.0", default-features = false, optional = true  }
 frame-executive = { version = "3.0.0", default-features = false }
 frame-support = { version = "3.0.0", default-features = false }
 frame-system = { version = "3.0.0", default-features = false }
@@ -109,6 +110,7 @@ std = [
 	"codec/std",
 	"log/std",
 	"frame-benchmarking/std",
+	"frame-try-runtime/std",
 	"frame-executive/std",
 	"frame-support/std",
 	"frame-system-rpc-runtime-api/std",
@@ -191,4 +193,11 @@ runtime-benchmarks = [
 	"bifrost-flexible-fee/runtime-benchmarks",
 	"bifrost-vtoken-mint/runtime-benchmarks",
 	"bifrost-minter-reward/runtime-benchmarks",
+]
+
+try-runtime = [
+	"frame-executive/try-runtime",
+	"frame-try-runtime",
+	"frame-system/try-runtime",
+	"pallet-vesting/try-runtime",
 ]

--- a/runtime/dev/src/lib.rs
+++ b/runtime/dev/src/lib.rs
@@ -1500,6 +1500,15 @@ impl_runtime_apis! {
 			Ok(batches)
 		}
 	}
+
+	#[cfg(feature = "try-runtime")]
+	impl frame_try_runtime::TryRuntime<Block> for Runtime {
+		fn on_runtime_upgrade() -> Result<(Weight, Weight), sp_runtime::RuntimeString> {
+			log::info!("try-runtime::on_runtime_upgrade bifrost.");
+			let weight = Executive::try_runtime_upgrade()?;
+			Ok((weight, RuntimeBlockWeights::get().max_block))
+		}
+	}
 }
 
 struct CheckInherents;

--- a/scripts/try-runtime.sh
+++ b/scripts/try-runtime.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+chain_type=$1
+chain_type="${chain_type:-bifrost}"
+
+chain_url=$2
+chain_url="${chain_url:-ws://localhost:9944}"
+
+block_hash=$3
+block_hash="${block_hash:-0xd854e0d78b2bcd9cc56b6b4897f13d937d8ee166f1cda3b6c748ce775c56a87d}"
+
+cargo run -p node-cli --locked --features with-$chain_type-runtime --features try-runtime -- try-runtime --chain="$chain_type-genesis" --wasm-execution=compiled --url="$chain_url" --block-at="$block_hash" on-runtime-upgrade live -s snapshot.bin


### PR DESCRIPTION
The `try-runtime` tool is mainly for running tests before launching a runtime to production and this pr includes:

 * Integate with command cli and runtime hooks
 * Refact to use macro `with_runtime_or_err`
 * Add entrance script
 * Upate readme accordingly
 