### PR TITLE
Revamp redeem flow in salp-lite

### DIFF
--- a/pallets/salp-lite/src/benchmarking.rs
+++ b/pallets/salp-lite/src/benchmarking.rs
@@ -54,24 +54,6 @@ fn contribute_fund<T: Config>(who: &T::AccountId, index: ParaId) {
 
 benchmarks! {
 
-	refund {
-		let fund_index = create_fund::<T>(1);
-		let caller: T::AccountId = whitelisted_caller();
-		let caller_origin: T::Origin = RawOrigin::Signed(caller.clone()).into();
-		let contribution = T::MinContribution::get();
-		contribute_fund::<T>(&caller,fund_index);
-		assert_ok!(Salp::<T>::fund_fail(RawOrigin::Root.into(), fund_index));
-		assert_ok!(Salp::<T>::withdraw(RawOrigin::Root.into(), fund_index));
-		let fund = Salp::<T>::funds(fund_index).unwrap();
-		let (_, status) = Salp::<T>::contribution(fund.trie_index, &caller);
-		assert_eq!(status, ContributionStatus::Idle);
-	}: _(RawOrigin::Signed(caller.clone()), fund_index)
-	verify {
-		let (_, status) = Salp::<T>::contribution(fund.trie_index, &caller);
-		assert_eq!(status, ContributionStatus::Idle);
-		assert_last_event::<T>(Event::<T>::Refunded(caller.clone(), fund_index, contribution).into())
-	}
-
 	redeem {
 		let fund_index = create_fund::<T>(1);
 		let caller: T::AccountId = whitelisted_caller();

--- a/pallets/salp-lite/src/mock.rs
+++ b/pallets/salp-lite/src/mock.rs
@@ -251,10 +251,6 @@ impl WeightInfo for SalpWeightInfo {
 		0
 	}
 
-	fn refund() -> Weight {
-		0
-	}
-
 	fn batch_migrate(_k: u32) -> Weight {
 		0
 	}

--- a/runtime/asgard/src/weights/bifrost_salp_lite.rs
+++ b/runtime/asgard/src/weights/bifrost_salp_lite.rs
@@ -49,20 +49,6 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> bifrost_salp_lite::WeightInfo for WeightInfo<T> {
 	// Storage: SalpLite Funds (r:1 w:0)
 	// Storage: Tokens Accounts (r:2 w:2)
-	// Storage: Tokens TotalIssuance (r:2 w:2)
-	// Storage: System Number (r:1 w:0)
-	// Storage: System ExecutionPhase (r:1 w:0)
-	// Storage: System EventCount (r:1 w:1)
-	// Storage: System Events (r:1 w:1)
-	// Storage: unknown [0xd861ea1ebf4800d4b89f4ff787ad79ee96d9a708c85b57da7eb8f9ddeda61291] (r:1 w:1)
-	fn refund() -> Weight {
-		(95_159_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-	}
-	
-	// Storage: SalpLite Funds (r:1 w:0)
-	// Storage: Tokens Accounts (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: System Number (r:1 w:0)
 	// Storage: System ExecutionPhase (r:1 w:0)

--- a/runtime/bifrost/src/weights/bifrost_salp_lite.rs
+++ b/runtime/bifrost/src/weights/bifrost_salp_lite.rs
@@ -49,19 +49,6 @@ pub struct WeightInfo<T>(PhantomData<T>);
 impl<T: frame_system::Config> bifrost_salp_lite::WeightInfo for WeightInfo<T> {
 	// Storage: SalpLite Funds (r:1 w:0)
 	// Storage: Tokens Accounts (r:2 w:2)
-	// Storage: Tokens TotalIssuance (r:2 w:2)
-	// Storage: System Number (r:1 w:0)
-	// Storage: System ExecutionPhase (r:1 w:0)
-	// Storage: System EventCount (r:1 w:1)
-	// Storage: System Events (r:1 w:1)
-	// Storage: unknown [0xd861ea1ebf4800d4b89f4ff787ad79ee96d9a708c85b57da7eb8f9ddeda61291] (r:1 w:1)
-	fn refund() -> Weight {
-		(95_159_000 as Weight)
-			.saturating_add(T::DbWeight::get().reads(10 as Weight))
-			.saturating_add(T::DbWeight::get().writes(7 as Weight))
-	}
-	// Storage: SalpLite Funds (r:1 w:0)
-	// Storage: Tokens Accounts (r:2 w:2)
 	// Storage: System Account (r:1 w:1)
 	// Storage: System Number (r:1 w:0)
 	// Storage: System ExecutionPhase (r:1 w:0)


### PR DESCRIPTION
- allow redeem when fund failed
- check redeem value less than token owned
- check redeem value less than total in redeem pool