### PR TITLE
Remove cargo-features = ["named-profiles"]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["named-profiles"]
-
 [workspace]
 members = [
 	"integration-tests",


### PR DESCRIPTION
Cargo support for custom profiles since [Rust-1.57.0](https://blog.rust-lang.org/2021/12/02/Rust-1.57.0.html)