### PR TITLE
Remove resolver = "2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ members = [
 	"xcm-support",
 ]
 
-resolver = "2"
-
 [profile.dev]
 split-debuginfo = "unpacked"
 


### PR DESCRIPTION
`edition = "2021"` implies `resolver = "2"` in Cargo.toml