### PR TITLE
more detailed error handling

### DIFF
--- a/runtime/bifrost-kusama/src/lib.rs
+++ b/runtime/bifrost-kusama/src/lib.rs
@@ -54,8 +54,7 @@ pub use sp_runtime::BuildStorage;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{
-		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, StaticLookup,
-		UniqueSaturatedInto, Zero,
+		AccountIdConversion, AccountIdLookup, BlakeTwo256, Block as BlockT, StaticLookup, Zero,
 	},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult, DispatchError, DispatchResult, Perbill, Permill, SaturatedConversion,

--- a/runtime/bifrost-kusama/src/lib.rs
+++ b/runtime/bifrost-kusama/src/lib.rs
@@ -1961,13 +1961,19 @@ where
 	Local: MultiCurrency<AccountId, CurrencyId = CurrencyId>,
 {
 	fn local_balance_of(asset_id: ZenlinkAssetId, who: &AccountId) -> AssetBalance {
-		let currency_id: CurrencyId = asset_id.try_into().unwrap_or_default();
-		Local::free_balance(currency_id, &who).saturated_into()
+		if let Ok(currency_id) = asset_id.try_into() {
+			return TryInto::<AssetBalance>::try_into(Local::free_balance(currency_id, &who))
+				.unwrap_or_default();
+		}
+		AssetBalance::default()
 	}
 
 	fn local_total_supply(asset_id: ZenlinkAssetId) -> AssetBalance {
-		let currency_id: CurrencyId = asset_id.try_into().unwrap_or_default();
-		Local::total_issuance(currency_id).saturated_into()
+		if let Ok(currency_id) = asset_id.try_into() {
+			return TryInto::<AssetBalance>::try_into(Local::total_issuance(currency_id))
+				.unwrap_or_default();
+		}
+		AssetBalance::default()
 	}
 
 	fn local_is_exists(asset_id: ZenlinkAssetId) -> bool {
@@ -1984,10 +1990,18 @@ where
 		target: &AccountId,
 		amount: AssetBalance,
 	) -> DispatchResult {
-		let currency_id: CurrencyId = asset_id.try_into().unwrap_or_default();
-		Local::transfer(currency_id, &origin, &target, amount.unique_saturated_into())?;
-
-		Ok(())
+		if let Ok(currency_id) = asset_id.try_into() {
+			Local::transfer(
+				currency_id,
+				&origin,
+				&target,
+				amount
+					.try_into()
+					.map_err(|_| DispatchError::Other("convert amount in local transfer"))?,
+			)
+		} else {
+			Err(DispatchError::Other("unknown asset in local transfer"))
+		}
 	}
 
 	fn local_deposit(
@@ -1995,9 +2009,19 @@ where
 		origin: &AccountId,
 		amount: AssetBalance,
 	) -> Result<AssetBalance, DispatchError> {
-		let currency_id: CurrencyId = asset_id.try_into().unwrap_or_default();
-		Local::deposit(currency_id, &origin, amount.unique_saturated_into())?;
-		return Ok(amount);
+		if let Ok(currency_id) = asset_id.try_into() {
+			Local::deposit(
+				currency_id,
+				&origin,
+				amount
+					.try_into()
+					.map_err(|_| DispatchError::Other("convert amount in local deposit"))?,
+			)?;
+		} else {
+			return Err(DispatchError::Other("unknown asset in local transfer"));
+		}
+
+		Ok(amount)
 	}
 
 	fn local_withdraw(
@@ -2005,8 +2029,17 @@ where
 		origin: &AccountId,
 		amount: AssetBalance,
 	) -> Result<AssetBalance, DispatchError> {
-		let currency_id: CurrencyId = asset_id.try_into().unwrap_or_default();
-		Local::withdraw(currency_id, &origin, amount.unique_saturated_into())?;
+		if let Ok(currency_id) = asset_id.try_into() {
+			Local::withdraw(
+				currency_id,
+				&origin,
+				amount
+					.try_into()
+					.map_err(|_| DispatchError::Other("convert amount in local withdraw"))?,
+			)?;
+		} else {
+			return Err(DispatchError::Other("unknown asset in local transfer"));
+		}
 
 		Ok(amount)
 	}

--- a/runtime/bifrost-polkadot/src/lib.rs
+++ b/runtime/bifrost-polkadot/src/lib.rs
@@ -53,9 +53,9 @@ use sp_core::OpaqueMetadata;
 pub use sp_runtime::BuildStorage;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, UniqueSaturatedInto, Zero},
+	traits::{AccountIdConversion, BlakeTwo256, Block as BlockT, Zero},
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, DispatchError, DispatchResult, Perbill, Permill, SaturatedConversion,
+	ApplyExtrinsicResult, DispatchError, DispatchResult, Perbill, Permill,
 };
 use sp_std::{marker::PhantomData, prelude::*};
 #[cfg(feature = "std")]


### PR DESCRIPTION
We should adopt stricter error handling in the interaction between Zenlink Protocol and ORML Token.　Using default values may result in loss of user assets when assets are converted incorrectly．