### PR TITLE
Add HashedDescription XCM location converter

### DIFF
--- a/runtime/bifrost-kusama/src/xcm_config.rs
+++ b/runtime/bifrost-kusama/src/xcm_config.rs
@@ -31,10 +31,11 @@ pub use polkadot_parachain_primitives::primitives::Sibling;
 use sp_std::{convert::TryFrom, marker::PhantomData};
 pub use xcm_builder::{
 	AccountId32Aliases, AllowKnownQueryResponses, AllowSubscriptionsFrom,
-	AllowTopLevelPaidExecutionFrom, CurrencyAdapter, EnsureXcmOrigin, FixedRateOfFungible,
-	FixedWeightBounds, IsConcrete, ParentAsSuperuser, ParentIsPreset, RelayChainAsNative,
-	SiblingParachainAsNative, SiblingParachainConvertsVia, SignedAccountId32AsNative,
-	SignedToAccountId32, SovereignSignedViaLocation, TakeRevenue, TakeWeightCredit,
+	AllowTopLevelPaidExecutionFrom, CurrencyAdapter, DescribeAllTerminal, DescribeFamily,
+	EnsureXcmOrigin, FixedRateOfFungible, FixedWeightBounds, HashedDescription, IsConcrete,
+	ParentAsSuperuser, ParentIsPreset, RelayChainAsNative, SiblingParachainAsNative,
+	SiblingParachainConvertsVia, SignedAccountId32AsNative, SignedToAccountId32,
+	SovereignSignedViaLocation, TakeRevenue, TakeWeightCredit,
 };
 use xcm_executor::traits::{MatchesFungible, ShouldExecute};
 
@@ -260,6 +261,8 @@ pub type LocationToAccountId = (
 	// TODO: Generate remote accounts according to polkadot standards
 	// Derives a private `Account32` by hashing `("multiloc", received multilocation)`
 	Account32Hash<RelayNetwork, AccountId>,
+	// Foreign locations alias into accounts according to a hash of their standard description.
+	HashedDescription<AccountId, DescribeFamily<DescribeAllTerminal>>,
 );
 
 /// This is the type we use to convert an (incoming) XCM origin into a local `RuntimeOrigin`


### PR DESCRIPTION
This PR adds the common XCM location converter `HashedDescription`, which is used across the ecosystem, to Bifrost Kusama.

For reference, chains using `HashedDescription` include the [relay chain](https://github.com/polkadot-fellows/runtimes/blob/main/relay/kusama/src/xcm_config.rs#L76) and system parachains like the [Asset Hub](https://github.com/polkadot-fellows/runtimes/blob/main/system-parachains/asset-hubs/asset-hub-kusama/src/xcm_config.rs#L93).