### PR TITLE
Optimize flexible-fee pallet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1205,8 +1205,6 @@ dependencies = [
  "bifrost-asset-registry",
  "bifrost-currencies",
  "bifrost-primitives",
- "bifrost-salp",
- "bifrost-vtoken-voting",
  "bifrost-xcm-interface",
  "cumulus-primitives-core",
  "frame-benchmarking",

--- a/pallets/fee-share/src/lib.rs
+++ b/pallets/fee-share/src/lib.rs
@@ -30,7 +30,7 @@ mod benchmarking;
 
 pub mod weights;
 
-use bifrost_primitives::{CurrencyId, DistributionId, Price};
+use bifrost_primitives::{CurrencyId, DistributionId, Price, PriceFeeder};
 use frame_support::{
 	pallet_prelude::*,
 	sp_runtime::{
@@ -44,7 +44,6 @@ use frame_support::{
 use frame_system::pallet_prelude::*;
 use orml_traits::MultiCurrency;
 pub use pallet::*;
-use pallet_traits::PriceFeeder;
 use sp_std::cmp::Ordering;
 pub use weights::WeightInfo;
 

--- a/pallets/fee-share/src/mock.rs
+++ b/pallets/fee-share/src/mock.rs
@@ -41,7 +41,6 @@ use orml_traits::{
 	location::RelativeReserveProvider, parameter_type_with_key, DataFeeder, DataProvider,
 	DataProviderExtended, MultiCurrency,
 };
-use pallet_traits::PriceFeeder;
 use sp_core::ConstU32;
 use sp_runtime::{
 	traits::{AccountIdConversion, IdentityLookup, UniqueSaturatedInto},

--- a/pallets/fee-share/src/mock.rs
+++ b/pallets/fee-share/src/mock.rs
@@ -278,11 +278,21 @@ impl PriceFeeder for MockPriceFeeder {
 		todo!()
 	}
 
+	fn get_amount_by_prices(
+		_currency_in: &CurrencyId,
+		_amount_in: bifrost_primitives::Balance,
+		_currency_in_price: Price,
+		_currency_out: &CurrencyId,
+		_currency_out_price: Price,
+	) -> Option<bifrost_primitives::Balance> {
+		todo!()
+	}
+
 	fn get_oracle_amount_by_currency_and_amount_in(
 		_currency_in: &CurrencyId,
 		_amount_in: bifrost_primitives::Balance,
 		_currency_out: &CurrencyId,
-	) -> Option<bifrost_primitives::Balance> {
+	) -> Option<(bifrost_primitives::Balance, Price, Price)> {
 		todo!()
 	}
 }

--- a/pallets/flexible-fee/Cargo.toml
+++ b/pallets/flexible-fee/Cargo.toml
@@ -32,13 +32,11 @@ bifrost-currencies = { workspace = true }
 sp-core = { workspace = true }
 sp-io = { workspace = true }
 cumulus-primitives-core = { workspace = true }
-bifrost-salp = { workspace = true }
 bifrost-asset-registry = { workspace = true }
 bifrost-xcm-interface = { workspace = true }
 xcm-executor = { workspace = true }
 xcm-builder = { workspace = true }
 pallet-xcm = { workspace = true }
-bifrost-vtoken-voting = { workspace = true, features = ["kusama"] }
 
 [features]
 default = ["std"]

--- a/pallets/flexible-fee/src/impls/account_fee_currency.rs
+++ b/pallets/flexible-fee/src/impls/account_fee_currency.rs
@@ -1,0 +1,95 @@
+// This file is part of Bifrost.
+
+// Copyright (C) Liebi Technologies PTE. LTD.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Config, Error, Pallet, UniversalFeeCurrencyOrderList, UserDefaultFeeCurrency};
+use bifrost_primitives::{AccountFeeCurrency, BalanceCmp, CurrencyId, WETH};
+use frame_support::traits::{
+	fungibles::Inspect,
+	tokens::{Fortitude, Preservation},
+};
+use sp_arithmetic::traits::UniqueSaturatedInto;
+use sp_core::U256;
+use sp_std::cmp::Ordering;
+
+/// Provides account's fee payment asset or default fee asset ( Native asset )
+impl<T: Config> AccountFeeCurrency<T::AccountId> for Pallet<T> {
+	type Error = Error<T>;
+
+	/// Determines the appropriate currency to be used for paying transaction fees based on a
+	/// prioritized order:
+	/// 1. User's default fee currency (`UserDefaultFeeCurrency`)
+	/// 2. WETH
+	/// 3. Currencies in the `UniversalFeeCurrencyOrderList`
+	///
+	/// The method first checks if the balance of the highest-priority currency is sufficient to
+	/// cover the fee.If the balance is insufficient, it iterates through the list of currencies in
+	/// priority order.If no currency has a sufficient balance, it returns the currency with the
+	/// highest balance.
+	fn get_fee_currency(account: &T::AccountId, fee: U256) -> Result<CurrencyId, Error<T>> {
+		let fee: u128 = fee.unique_saturated_into();
+		let priority_currency = UserDefaultFeeCurrency::<T>::get(account);
+		let mut currency_list = UniversalFeeCurrencyOrderList::<T>::get();
+
+		let first_item_index = 0;
+		currency_list
+			.try_insert(first_item_index, WETH)
+			.map_err(|_| Error::<T>::MaxCurrenciesReached)?;
+
+		// When all currency balances are insufficient, return the one with the highest balance
+		let mut hopeless_currency = WETH;
+
+		if let Some(currency) = priority_currency {
+			currency_list
+				.try_insert(first_item_index, currency)
+				.map_err(|_| Error::<T>::MaxCurrenciesReached)?;
+			hopeless_currency = currency;
+		}
+
+		for maybe_currency in currency_list.iter() {
+			let comp_res = Self::cmp_with_precision(account, maybe_currency, fee, 18)?;
+
+			match comp_res {
+				Ordering::Less => {
+					// Get the currency with the highest balance
+					let hopeless_currency_balance = T::MultiCurrency::reducible_balance(
+						hopeless_currency,
+						account,
+						Preservation::Preserve,
+						Fortitude::Polite,
+					);
+					let maybe_currency_balance = T::MultiCurrency::reducible_balance(
+						*maybe_currency,
+						account,
+						Preservation::Preserve,
+						Fortitude::Polite,
+					);
+					hopeless_currency = match hopeless_currency_balance.cmp(&maybe_currency_balance)
+					{
+						Ordering::Less => *maybe_currency,
+						_ => hopeless_currency,
+					};
+					continue;
+				},
+				Ordering::Equal => return Ok(*maybe_currency),
+				Ordering::Greater => return Ok(*maybe_currency),
+			};
+		}
+
+		return Ok(hopeless_currency);
+	}
+}

--- a/pallets/flexible-fee/src/impls/mod.rs
+++ b/pallets/flexible-fee/src/impls/mod.rs
@@ -16,28 +16,5 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![cfg(feature = "runtime-benchmarks")]
-
-use frame_benchmarking::v1::{benchmarks, whitelisted_caller};
-use frame_support::BoundedVec;
-
-use bifrost_primitives::{CurrencyId, TokenSymbol};
-use frame_system::RawOrigin;
-use sp_std::vec;
-
-use crate::{Call, Config, Pallet};
-
-benchmarks! {
-	set_user_default_fee_currency {
-		let caller = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller),Some(CurrencyId::Token(TokenSymbol::DOT)))
-
-	set_default_fee_currency_list {
-		let default_list = BoundedVec::try_from(vec![CurrencyId::Token(TokenSymbol::DOT)]).unwrap();
-	}: _(RawOrigin::Root,default_list)
-
-	impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(),
-	crate::mock::Test)
-}
+pub mod account_fee_currency;
+pub mod on_charge_transaction;

--- a/pallets/flexible-fee/src/impls/on_charge_transaction.rs
+++ b/pallets/flexible-fee/src/impls/on_charge_transaction.rs
@@ -1,0 +1,146 @@
+// This file is part of Bifrost.
+
+// Copyright (C) Liebi Technologies PTE. LTD.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+use crate::{Config, ExtraFeeByCall, Pallet};
+use bifrost_primitives::{Balance, CurrencyId, PriceFeeder, BNC};
+use orml_traits::MultiCurrency;
+use pallet_transaction_payment::OnChargeTransaction;
+use parity_scale_codec::Encode;
+use sp_core::Get;
+use sp_runtime::{
+	traits::{DispatchInfoOf, PostDispatchInfoOf, Zero},
+	transaction_validity::{InvalidTransaction, TransactionValidityError},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PaymentInfo {
+	Native(Balance),
+	NonNative(Balance, CurrencyId),
+}
+
+/// Default implementation for a Currency and an OnUnbalanced handler.
+impl<T> OnChargeTransaction<T> for Pallet<T>
+where
+	T: Config,
+	T::MultiCurrency: MultiCurrency<T::AccountId, CurrencyId = CurrencyId>,
+{
+	type Balance = Balance;
+	type LiquidityInfo = Option<PaymentInfo>;
+
+	/// Withdraw the predicted fee from the transaction origin.
+	///
+	/// Note: The `fee` already includes the `tip`.
+	fn withdraw_fee(
+		who: &T::AccountId,
+		call: &T::RuntimeCall,
+		_info: &DispatchInfoOf<T::RuntimeCall>,
+		fee: Self::Balance,
+		_tip: Self::Balance,
+	) -> Result<Self::LiquidityInfo, TransactionValidityError> {
+		if fee.is_zero() {
+			return Ok(None);
+		}
+
+		let (fee_currency, fee_amount) = Self::get_fee_currency_and_fee_amount(who, fee)
+			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+
+		// withdraw normal extrinsic fee
+		T::MultiCurrency::withdraw(fee_currency, who, fee_amount)
+			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+
+		for (call_name, (extra_fee_currency, extra_fee_amount, extra_fee_receiver)) in
+			ExtraFeeByCall::<T>::iter()
+		{
+			if call.encode()[0..2].to_vec().eq(&call_name.to_vec()) {
+				match Self::charge_extra_fee(
+					who,
+					extra_fee_currency,
+					extra_fee_amount,
+					&extra_fee_receiver,
+				) {
+					Ok(_) => {},
+					Err(_) => {
+						return Err(TransactionValidityError::Invalid(InvalidTransaction::Payment));
+					},
+				}
+			};
+		}
+
+		if fee_currency == BNC {
+			Ok(Some(PaymentInfo::Native(fee_amount)))
+		} else {
+			Ok(Some(PaymentInfo::NonNative(fee_amount, fee_currency)))
+		}
+	}
+
+	/// Hand the fee and the tip over to the `[OnUnbalanced]` implementation.
+	/// Since the predicted fee might have been too high, parts of the fee may
+	/// be refunded.
+	///
+	/// Note: The `fee` already includes the `tip`.
+	fn correct_and_deposit_fee(
+		who: &T::AccountId,
+		_dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
+		_post_info: &PostDispatchInfoOf<T::RuntimeCall>,
+		corrected_fee: Self::Balance,
+		tip: Self::Balance,
+		already_withdrawn: Self::LiquidityInfo,
+	) -> Result<(), TransactionValidityError> {
+		if let Some(paid) = already_withdrawn {
+			// Calculate how much refund we should return
+			let (currency, refund, fee, tip) = match paid {
+				PaymentInfo::Native(paid_fee) => (
+					BNC,
+					paid_fee.saturating_sub(corrected_fee),
+					corrected_fee.saturating_sub(tip),
+					tip,
+				),
+				PaymentInfo::NonNative(paid_fee, currency) => {
+					// calculate corrected_fee in the non-native currency
+					let converted_corrected_fee =
+						T::PriceFeeder::get_oracle_amount_by_currency_and_amount_in(
+							&BNC,
+							corrected_fee,
+							&currency,
+						)
+						.ok_or(TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+					let refund = paid_fee.saturating_sub(converted_corrected_fee);
+					let converted_tip =
+						T::PriceFeeder::get_oracle_amount_by_currency_and_amount_in(
+							&BNC, tip, &currency,
+						)
+						.ok_or(TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+					(
+						currency,
+						refund,
+						converted_corrected_fee.saturating_sub(converted_tip),
+						converted_tip,
+					)
+				},
+			};
+			// refund to the account that paid the fees
+			T::MultiCurrency::deposit(currency, who, refund)
+				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+
+			// deposit the fee
+			T::MultiCurrency::deposit(currency, &T::TreasuryAccount::get(), fee + tip)
+				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
+		}
+		Ok(())
+	}
+}

--- a/pallets/flexible-fee/src/lib.rs
+++ b/pallets/flexible-fee/src/lib.rs
@@ -21,9 +21,9 @@
 pub use crate::pallet::*;
 use bifrost_primitives::{
 	currency::{VGLMR, VMANTA, WETH},
-	traits::{FeeGetter, XcmDestWeightAndFeeHandler},
-	AccountFeeCurrency, BalanceCmp, CurrencyId, ExtraFeeName, TryConvertFrom, XcmOperationType,
-	BNC, DOT, GLMR, MANTA, VBNC, VDOT,
+	traits::XcmDestWeightAndFeeHandler,
+	Balance, BalanceCmp, CurrencyId, DerivativeIndex, PriceFeeder, TryConvertFrom,
+	XcmOperationType, BNC, DOT, GLMR, MANTA, VBNC, VDOT,
 };
 use bifrost_xcm_interface::{polkadot::RelaychainCall, traits::parachains, PolkadotXcmCall};
 use core::convert::Into;
@@ -33,8 +33,7 @@ use frame_support::{
 	traits::{
 		fungibles::Inspect,
 		tokens::{Fortitude, Preservation},
-		Currency, ExistenceRequirement, Get, Imbalance, OnUnbalanced, ReservableCurrency,
-		WithdrawReasons,
+		Get,
 	},
 	transactional,
 	weights::WeightMeter,
@@ -42,37 +41,26 @@ use frame_support::{
 };
 use frame_system::pallet_prelude::*;
 use orml_traits::MultiCurrency;
-use pallet_transaction_payment::OnChargeTransaction;
 use polkadot_parachain_primitives::primitives::Sibling;
-use sp_arithmetic::traits::{CheckedAdd, SaturatedConversion, UniqueSaturatedInto};
-use sp_core::U256;
-use sp_runtime::{
-	traits::{AccountIdConversion, DispatchInfoOf, PostDispatchInfoOf, Saturating, Zero},
-	transaction_validity::TransactionValidityError,
-	BoundedVec,
-};
+use sp_arithmetic::traits::UniqueSaturatedInto;
+use sp_runtime::{traits::AccountIdConversion, BoundedVec};
 use sp_std::{boxed::Box, cmp::Ordering, vec, vec::Vec};
 pub use weights::WeightInfo;
 use xcm::{prelude::Unlimited, v4::prelude::*};
-use zenlink_protocol::{AssetBalance, AssetId, ExportZenlink};
+use zenlink_protocol::{AssetId, ExportZenlink};
 
 #[cfg(feature = "runtime-benchmarks")]
 mod benchmarking;
+pub mod impls;
 pub mod migrations;
 mod mock;
+mod mock_price;
 mod tests;
 pub mod weights;
 
 pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
-pub type CurrencyIdOf<T> =
-	<<T as Config>::MultiCurrency as MultiCurrency<AccountIdOf<T>>>::CurrencyId;
 pub type BalanceOf<T> = <<T as Config>::MultiCurrency as MultiCurrency<AccountIdOf<T>>>::Balance;
-pub type PalletBalanceOf<T> = <<T as Config>::Currency as Currency<AccountIdOf<T>>>::Balance;
-pub type NegativeImbalanceOf<T> =
-	<<T as Config>::Currency as Currency<AccountIdOf<T>>>::NegativeImbalance;
-pub type PositiveImbalanceOf<T> =
-	<<T as Config>::Currency as Currency<AccountIdOf<T>>>::PositiveImbalance;
-pub type CallOf<T> = <T as frame_system::Config>::RuntimeCall;
+pub type RawCallName = BoundedVec<u8, ConstU32<2>>;
 
 #[derive(Encode, Decode, Copy, Clone, Eq, PartialEq, RuntimeDebug, TypeInfo, MaxEncodedLen)]
 pub enum TargetChain {
@@ -83,7 +71,7 @@ pub enum TargetChain {
 #[frame_support::pallet]
 pub mod pallet {
 	use super::*;
-	use bifrost_primitives::Balance;
+	use bifrost_primitives::{Balance, PriceFeeder};
 	use frame_support::traits::fungibles::Inspect;
 
 	#[pallet::config]
@@ -93,43 +81,35 @@ pub mod pallet {
 		/// Weight information for the extrinsics in this module.
 		type WeightInfo: WeightInfo;
 		/// Handler for both NativeCurrency and MultiCurrency
-		type MultiCurrency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = PalletBalanceOf<Self>>
+		type MultiCurrency: MultiCurrency<Self::AccountId, CurrencyId = CurrencyId, Balance = Balance>
 			+ Inspect<Self::AccountId, AssetId = CurrencyId, Balance = Balance>;
-		/// The currency type in which fees will be paid.
-		type Currency: Currency<Self::AccountId> + ReservableCurrency<Self::AccountId>;
-		/// Handler for the unbalanced decrease
-		type OnUnbalanced: OnUnbalanced<NegativeImbalanceOf<Self>>;
 		/// xcm transfer interface
 		type XcmRouter: SendXcm;
-
+		/// Zenlink interface
 		type DexOperator: ExportZenlink<Self::AccountId, AssetId>;
-		/// Filter if this transaction needs to be deducted extra fee besides basic transaction fee,
-		/// and get the name of the fee
-		type ExtraFeeMatcher: FeeGetter<CallOf<Self>>;
-
-		#[pallet::constant]
-		type TreasuryAccount: Get<Self::AccountId>;
-
-		#[pallet::constant]
-		type MaxFeeCurrencyOrderListLen: Get<u32>;
-
-		#[pallet::constant]
-		type MinAssetHubExecutionFee: Get<BalanceOf<Self>>;
-
-		#[pallet::constant]
-		type MinRelaychainExecutionFee: Get<BalanceOf<Self>>;
-
-		/// The currency id of the RelayChain
-		#[pallet::constant]
-		type RelaychainCurrencyId: Get<CurrencyIdOf<Self>>;
-
-		type ParachainId: Get<ParaId>;
-
+		/// The oracle price feeder
+		type PriceFeeder: PriceFeeder;
 		/// The only origin that can set universal fee currency order list
 		type ControlOrigin: EnsureOrigin<Self::RuntimeOrigin>;
-
-		type XcmWeightAndFeeHandler: XcmDestWeightAndFeeHandler<CurrencyId, PalletBalanceOf<Self>>;
-
+		/// Get the weight and fee for executing Xcm.
+		type XcmWeightAndFeeHandler: XcmDestWeightAndFeeHandler<CurrencyId, Balance>;
+		/// Get TreasuryAccount
+		#[pallet::constant]
+		type TreasuryAccount: Get<Self::AccountId>;
+		/// Maximum number of CurrencyId's to support handling fees.
+		#[pallet::constant]
+		type MaxFeeCurrencyOrderListLen: Get<u32>;
+		/// When this number is reached, the DOT is sent to AssetHub
+		#[pallet::constant]
+		type MinAssetHubExecutionFee: Get<BalanceOf<Self>>;
+		/// When this number is reached, the DOT is sent to Relaychain
+		#[pallet::constant]
+		type MinRelaychainExecutionFee: Get<BalanceOf<Self>>;
+		/// The currency id of the RelayChain
+		#[pallet::constant]
+		type RelaychainCurrencyId: Get<CurrencyId>;
+		#[pallet::constant]
+		type ParachainId: Get<ParaId>;
 		#[pallet::constant]
 		type PalletId: Get<PalletId>;
 	}
@@ -160,70 +140,55 @@ pub mod pallet {
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config> {
-		TransferTo {
-			from: T::AccountId,
-			target_chain: TargetChain,
-			amount: BalanceOf<T>,
-		},
-		FlexibleFeeExchanged {
-			transaction_fee_currency: CurrencyIdOf<T>,
-			transaction_fee_amount: PalletBalanceOf<T>,
-		}, // token and amount
-		FixedRateFeeExchanged(CurrencyIdOf<T>, PalletBalanceOf<T>),
-		// [extra_fee_name, currency_id, amount_in, BNC_amount_out]
-		ExtraFeeDeducted {
-			operation: ExtraFeeName,
-			transaction_extra_fee_currency: CurrencyIdOf<T>,
-			transaction_extra_fee_amount: PalletBalanceOf<T>,
-			transaction_extra_fee_bnc_amount: PalletBalanceOf<T>,
-			transaction_extra_fee_receiver: T::AccountId,
-		},
+		TransferTo { from: T::AccountId, target_chain: TargetChain, amount: BalanceOf<T> },
 	}
-
-	/// The current storage version, we set to 2 our new version(after migrate stroage from vec t
-	/// boundedVec).
-	#[allow(unused)]
-	const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
 	/// Universal fee currency order list for all users
 	#[pallet::storage]
 	pub type UniversalFeeCurrencyOrderList<T: Config> =
-		StorageValue<_, BoundedVec<CurrencyIdOf<T>, T::MaxFeeCurrencyOrderListLen>, ValueQuery>;
+		StorageValue<_, BoundedVec<CurrencyId, T::MaxFeeCurrencyOrderListLen>, ValueQuery>;
 
 	/// User default fee currency, if set, will be used as the first fee currency, and then use the
 	/// universal fee currency order list
 	#[pallet::storage]
 	pub type UserDefaultFeeCurrency<T: Config> =
-		StorageMap<_, Twox64Concat, T::AccountId, CurrencyIdOf<T>, OptionQuery>;
+		StorageMap<_, Twox64Concat, T::AccountId, CurrencyId, OptionQuery>;
+
+	/// Methods of storing extra charges.
+	#[pallet::storage]
+	pub type ExtraFeeByCall<T: Config> = StorageMap<
+		_,
+		Twox64Concat,
+		RawCallName,
+		(CurrencyId, BalanceOf<T>, T::AccountId),
+		OptionQuery,
+	>;
 
 	#[pallet::pallet]
-	#[pallet::without_storage_info]
-	#[pallet::storage_version(STORAGE_VERSION)]
-	pub struct Pallet<T>(PhantomData<T>);
+	pub struct Pallet<T>(_);
 
 	#[pallet::error]
 	pub enum Error<T> {
 		NotEnoughBalance,
-		Overflow,
 		ConversionError,
-		WrongListLength,
 		WeightAndFeeNotExist,
-		DexFailedToGetAmountInByPath,
 		UnweighableMessage,
 		XcmExecutionFailed,
-		/// Maximum number of currencies reached.
-		MaxCurrenciesReached,
 		CurrencyNotSupport,
+		MaxCurrenciesReached,
 	}
 
 	#[pallet::call]
 	impl<T: Config> Pallet<T> {
 		/// Set user default fee currency
+		/// Parameters:
+		/// - `maybe_fee_currency`: The currency id to be set as the default fee currency.
+		///  If `None`, the user default fee currency will be removed.
 		#[pallet::call_index(0)]
 		#[pallet::weight(<T as Config>::WeightInfo::set_user_default_fee_currency())]
 		pub fn set_user_default_fee_currency(
 			origin: OriginFor<T>,
-			maybe_fee_currency: Option<CurrencyIdOf<T>>,
+			maybe_fee_currency: Option<CurrencyId>,
 		) -> DispatchResult {
 			let who = ensure_signed(origin)?;
 
@@ -237,18 +202,36 @@ pub mod pallet {
 		}
 
 		/// Set universal fee currency order list
+		/// Parameters:
+		/// - `default_list`: The currency id list to be set as the universal fee currency order
+		///   list.
 		#[pallet::call_index(1)]
-		#[pallet::weight(<T as Config>::WeightInfo::set_universal_fee_currency_order_list())]
-		pub fn set_universal_fee_currency_order_list(
+		#[pallet::weight(<T as Config>::WeightInfo::set_default_fee_currency_list())]
+		pub fn set_default_fee_currency_list(
 			origin: OriginFor<T>,
-			default_list: BoundedVec<CurrencyIdOf<T>, T::MaxFeeCurrencyOrderListLen>,
+			default_list: BoundedVec<CurrencyId, T::MaxFeeCurrencyOrderListLen>,
 		) -> DispatchResult {
 			T::ControlOrigin::ensure_origin(origin)?;
+			UniversalFeeCurrencyOrderList::<T>::put(default_list);
+			Ok(())
+		}
 
-			ensure!(default_list.len() > 0 as usize, Error::<T>::WrongListLength);
-
-			UniversalFeeCurrencyOrderList::<T>::set(default_list);
-
+		/// Set universal fee currency order list
+		/// Parameters:
+		/// - `raw_call_name`: The raw call name to be set as the extra fee call.
+		/// - `fee_info`: The currency id, fee amount and receiver to be set as the extra fee.
+		#[pallet::call_index(2)]
+		#[pallet::weight(<T as Config>::WeightInfo::set_user_default_fee_currency())]
+		pub fn set_extra_fee(
+			origin: OriginFor<T>,
+			raw_call_name: RawCallName,
+			fee_info: Option<(CurrencyId, BalanceOf<T>, T::AccountId)>,
+		) -> DispatchResult {
+			T::ControlOrigin::ensure_origin(origin)?;
+			match fee_info {
+				Some(fee_info) => ExtraFeeByCall::<T>::insert(&raw_call_name, fee_info),
+				None => ExtraFeeByCall::<T>::remove(&raw_call_name),
+			};
 			Ok(())
 		}
 	}
@@ -257,7 +240,7 @@ pub mod pallet {
 impl<T: Config> Pallet<T> {
 	#[transactional]
 	fn handle_fee() -> DispatchResult {
-		let fee_receiver = Self::get_fee_receiver(ExtraFeeName::StatemineTransfer);
+		let fee_receiver = Self::get_fee_receiver(1);
 		let fee_receiver_balance =
 			T::MultiCurrency::free_balance(T::RelaychainCurrencyId::get(), &fee_receiver);
 		if fee_receiver_balance >= T::MinAssetHubExecutionFee::get() {
@@ -304,10 +287,7 @@ impl<T: Config> Pallet<T> {
 				)
 				.ok_or(Error::<T>::WeightAndFeeNotExist)?;
 
-			let fee: Asset = Asset {
-				id: AssetId(Location::here()),
-				fun: Fungible(UniqueSaturatedInto::<u128>::unique_saturated_into(xcm_fee)),
-			};
+			let fee: Asset = Asset { id: AssetId(Location::here()), fun: Fungible(xcm_fee) };
 
 			let remote_xcm = Xcm(vec![
 				WithdrawAsset(fee.clone().into()),
@@ -334,7 +314,7 @@ impl<T: Config> Pallet<T> {
 			});
 		}
 
-		let fee_receiver = Self::get_fee_receiver(ExtraFeeName::VoteVtoken);
+		let fee_receiver = Self::get_fee_receiver(0);
 		let fee_receiver_balance =
 			T::MultiCurrency::free_balance(T::RelaychainCurrencyId::get(), &fee_receiver);
 		if fee_receiver_balance >= T::MinRelaychainExecutionFee::get() {
@@ -354,369 +334,155 @@ impl<T: Config> Pallet<T> {
 		Ok(())
 	}
 
-	fn get_fee_receiver(extra_fee_name: ExtraFeeName) -> T::AccountId {
-		match extra_fee_name {
-			ExtraFeeName::SalpContribute |
-			ExtraFeeName::VoteVtoken |
-			ExtraFeeName::VoteRemoveDelegatorVote => T::PalletId::get().into_sub_account_truncating(0u64),
-			ExtraFeeName::StatemineTransfer | ExtraFeeName::EthereumTransfer =>
-				T::PalletId::get().into_sub_account_truncating(1u64),
-			ExtraFeeName::NoExtraFee => T::TreasuryAccount::get(),
-		}
+	fn get_fee_receiver(index: DerivativeIndex) -> T::AccountId {
+		T::PalletId::get().into_sub_account_truncating(index)
 	}
 
 	/// Get user fee charge assets order
-	fn inner_get_user_fee_charge_order_list(account_id: &T::AccountId) -> Vec<CurrencyIdOf<T>> {
-		let mut order_list: Vec<CurrencyIdOf<T>> = Vec::new();
-		// Get user default fee currency
-		if let Some(user_default_fee_currency) = UserDefaultFeeCurrency::<T>::get(&account_id) {
-			order_list.push(user_default_fee_currency);
-		};
-
+	fn get_fee_currency_list(account_id: &T::AccountId) -> Vec<CurrencyId> {
 		// Get universal fee currency order list
-		let mut universal_fee_currency_order_list: Vec<CurrencyIdOf<T>> =
+		let mut fee_currency_list: Vec<CurrencyId> =
 			UniversalFeeCurrencyOrderList::<T>::get().into_iter().collect();
 
-		// Concat user default fee currency and universal fee currency order list
-		order_list.append(&mut universal_fee_currency_order_list);
+		// Get user default fee currency
+		if let Some(default_fee_currency) = UserDefaultFeeCurrency::<T>::get(&account_id) {
+			if let Some(index) = fee_currency_list.iter().position(|&c| c == default_fee_currency) {
+				fee_currency_list.remove(index);
+			}
+			let first_fee_currency_index = 0;
+			fee_currency_list.insert(first_fee_currency_index, default_fee_currency);
+		};
 
-		order_list
+		fee_currency_list
 	}
 
-	fn find_out_fee_currency_and_amount(
+	fn get_fee_currency_and_fee_amount(
 		who: &T::AccountId,
-		fee: PalletBalanceOf<T>,
-	) -> Result<Option<(CurrencyIdOf<T>, PalletBalanceOf<T>, PalletBalanceOf<T>)>, Error<T>> {
-		// get the user defined fee charge order list.
-		let user_fee_charge_order_list = Self::inner_get_user_fee_charge_order_list(who);
-
+		fee_amount: Balance,
+	) -> Result<(CurrencyId, Balance), Error<T>> {
+		let fee_currency_list = Self::get_fee_currency_list(who);
 		// charge the fee by the order of the above order list.
 		// first to check whether the user has the asset. If no, pass it. If yes, try to make
 		// transaction in the DEX in exchange for BNC
-		for currency_id in user_fee_charge_order_list {
+		for currency_id in fee_currency_list {
 			// If it is mainnet currency
 			if currency_id == BNC {
-				// check native balance if is enough
-				if T::MultiCurrency::ensure_can_withdraw(currency_id, who, fee).is_ok() {
-					// currency, amount_in, amount_out
-					return Ok(Some((currency_id, fee, fee)));
+				if T::MultiCurrency::ensure_can_withdraw(currency_id, who, fee_amount).is_ok() {
+					return Ok((currency_id, fee_amount));
 				}
 			} else {
-				// If it is other assets, go to exchange fee amount.
-				let native_asset_id =
-					Self::get_currency_asset_id(BNC).map_err(|_| Error::<T>::ConversionError)?;
-
-				let amount_out: AssetBalance = fee.saturated_into();
-
-				let asset_id = Self::get_currency_asset_id(currency_id)
-					.map_err(|_| Error::<T>::ConversionError)?;
-
-				let path = vec![asset_id, native_asset_id];
-				// see if path exists, if not, continue.
-				// query for amount in
-				if let Ok(amounts) = T::DexOperator::get_amount_in_by_path(amount_out, &path) {
-					// make sure the user has enough free token balance that can be charged.
-					let amount_in = PalletBalanceOf::<T>::saturated_from(amounts[0]);
-					if T::MultiCurrency::ensure_can_withdraw(currency_id, who, amount_in).is_ok() {
-						// currency, amount_in, amount_out
-						return Ok(Some((
-							currency_id,
-							amount_in,
-							PalletBalanceOf::<T>::saturated_from(amount_out),
-						)));
-					}
+				let fee_amount = T::PriceFeeder::get_oracle_amount_by_currency_and_amount_in(
+					&BNC,
+					fee_amount,
+					&currency_id,
+				)
+				.ok_or(Error::<T>::ConversionError)?;
+				if T::MultiCurrency::ensure_can_withdraw(currency_id, who, fee_amount).is_ok() {
+					return Ok((currency_id, fee_amount));
 				}
 			}
 		}
-		Ok(None)
+		Err(Error::<T>::NotEnoughBalance)
 	}
 
-	/// Make sure there are enough BNC to be deducted if the user has assets in other form of tokens
-	/// rather than BNC.
-	fn ensure_can_charge_fee(
+	fn charge_extra_fee(
 		who: &T::AccountId,
-		fee: PalletBalanceOf<T>,
-		_reason: WithdrawReasons,
-	) -> Result<PalletBalanceOf<T>, DispatchError> {
-		let result_option = Self::find_out_fee_currency_and_amount(who, fee)
-			.map_err(|_| DispatchError::Other("Fee calculation Error."))?;
-
-		if let Some((currency_id, amount_in, amount_out)) = result_option {
-			if currency_id != BNC {
-				let native_asset_id = Self::get_currency_asset_id(BNC)?;
-				let asset_id = Self::get_currency_asset_id(currency_id)?;
-				let path = vec![asset_id, native_asset_id];
-
-				T::DexOperator::inner_swap_assets_for_exact_assets(
-					who,
-					amount_out.saturated_into(),
-					amount_in.saturated_into(),
-					&path,
-					who,
-				)?;
-
-				Self::deposit_event(Event::FlexibleFeeExchanged {
-					transaction_fee_currency: currency_id,
-					transaction_fee_amount: PalletBalanceOf::<T>::saturated_from(amount_in),
-				});
+		extra_fee_currency: CurrencyId,
+		extra_fee_amount: Balance,
+		extra_fee_receiver: &T::AccountId,
+	) -> Result<(), Error<T>> {
+		let fee_currency_list = Self::get_fee_currency_list(who);
+		// charge the fee by the order of the above order list.
+		// first to check whether the user has the asset. If no, pass it. If yes, try to make
+		// transaction in the DEX in exchange for BNC
+		let mut fee_info = None;
+		for currency_id in fee_currency_list {
+			// If it is mainnet currency
+			if currency_id == extra_fee_currency {
+				if T::MultiCurrency::ensure_can_withdraw(extra_fee_currency, who, extra_fee_amount)
+					.is_ok()
+				{
+					fee_info = Some((currency_id, extra_fee_amount));
+					break;
+				}
+			} else {
+				match Self::ensure_can_swap(who, currency_id, extra_fee_currency, extra_fee_amount)
+				{
+					Ok(amount_in) => {
+						fee_info = Some((currency_id, amount_in));
+						break;
+					},
+					Err(_) => {},
+				}
 			}
 		}
 
-		Ok(fee)
+		match fee_info {
+			Some((fee_currency, fee_amount)) =>
+				if fee_currency == extra_fee_currency {
+					T::MultiCurrency::transfer(fee_currency, who, extra_fee_receiver, fee_amount)
+						.map_err(|_| Error::<T>::NotEnoughBalance)?;
+					Ok(())
+				} else {
+					let from_asset_id = Self::get_currency_asset_id(fee_currency)?;
+					let to_asset_id = Self::get_currency_asset_id(extra_fee_currency)?;
+					let path = vec![from_asset_id, to_asset_id];
+
+					T::DexOperator::inner_swap_assets_for_exact_assets(
+						who,
+						extra_fee_amount,
+						fee_amount,
+						&path,
+						extra_fee_receiver,
+					)
+					.map_err(|_| Error::<T>::NotEnoughBalance)?;
+					Ok(())
+				},
+			None => Err(Error::<T>::ConversionError),
+		}
 	}
 
 	/// This function is for runtime-api to call
 	pub fn cal_fee_token_and_amount(
 		who: &T::AccountId,
-		fee: PalletBalanceOf<T>,
-		utx: &CallOf<T>,
-	) -> Result<(CurrencyIdOf<T>, PalletBalanceOf<T>), Error<T>> {
-		let total_fee_info = Self::get_extrinsic_and_extra_fee_total(utx, fee)?;
-		let (currency_id, amount_in, _amount_out) =
-			Self::find_out_fee_currency_and_amount(who, total_fee_info.0)
-				.map_err(|_| Error::<T>::DexFailedToGetAmountInByPath)?
-				.ok_or(Error::<T>::DexFailedToGetAmountInByPath)?;
-
-		Ok((currency_id, amount_in))
+		fee: Balance,
+		_utx: &<T as frame_system::Config>::RuntimeCall,
+	) -> Result<(CurrencyId, Balance), Error<T>> {
+		let (fee_currency, fee_amount) = Self::get_fee_currency_and_fee_amount(who, fee)
+			.map_err(|_| Error::<T>::NotEnoughBalance)?;
+		Ok((fee_currency, fee_amount))
 	}
 
-	pub fn get_extrinsic_and_extra_fee_total(
-		call: &CallOf<T>,
-		fee: PalletBalanceOf<T>,
-	) -> Result<(PalletBalanceOf<T>, PalletBalanceOf<T>, PalletBalanceOf<T>, Vec<AssetId>), Error<T>>
-	{
-		let mut total_fee = fee;
-
-		let native_asset_id = Self::get_currency_asset_id(BNC)?;
-		let mut path = vec![native_asset_id, native_asset_id];
-
-		// See if the this RuntimeCall needs to pay extra fee
-		let fee_info = T::ExtraFeeMatcher::get_fee_info(call);
-		if fee_info.extra_fee_name != ExtraFeeName::NoExtraFee {
-			// if the fee_info.extra_fee_name is not NoExtraFee, it means this RuntimeCall needs to
-			// pay extra fee
-			let operation = match fee_info.extra_fee_name {
-				ExtraFeeName::SalpContribute => XcmOperationType::UmpContributeTransact,
-				ExtraFeeName::StatemineTransfer => XcmOperationType::StatemineTransfer,
-				ExtraFeeName::EthereumTransfer => XcmOperationType::EthereumTransfer,
-				ExtraFeeName::VoteVtoken => XcmOperationType::Vote,
-				ExtraFeeName::VoteRemoveDelegatorVote => XcmOperationType::RemoveVote,
-				ExtraFeeName::NoExtraFee => XcmOperationType::Any,
-			};
-
-			let (_, fee_value) = T::XcmWeightAndFeeHandler::get_operation_weight_and_fee(
-				fee_info.extra_fee_currency,
-				operation,
-			)
-			.ok_or(Error::<T>::WeightAndFeeNotExist)?;
-
-			let asset_id = Self::get_currency_asset_id(fee_info.extra_fee_currency)?;
-			path = vec![native_asset_id, asset_id];
-
-			// get the fee currency value in BNC
-			let extra_fee_vec =
-				T::DexOperator::get_amount_in_by_path(fee_value.saturated_into(), &path)
-					.map_err(|_| Error::<T>::DexFailedToGetAmountInByPath)?;
-
-			let extra_bnc_fee = PalletBalanceOf::<T>::saturated_from(extra_fee_vec[0]);
-			total_fee = total_fee.checked_add(&extra_bnc_fee).ok_or(Error::<T>::Overflow)?;
-
-			return Ok((total_fee, extra_bnc_fee, fee_value, path));
-		} else {
-			return Ok((total_fee, Zero::zero(), Zero::zero(), path));
-		}
-	}
-
-	fn get_currency_asset_id(currency_id: CurrencyIdOf<T>) -> Result<AssetId, Error<T>> {
+	fn get_currency_asset_id(currency_id: CurrencyId) -> Result<AssetId, Error<T>> {
 		let asset_id: AssetId =
 			AssetId::try_convert_from(currency_id, T::ParachainId::get().into())
 				.map_err(|_| Error::<T>::ConversionError)?;
 		Ok(asset_id)
 	}
-}
 
-/// Default implementation for a Currency and an OnUnbalanced handler.
-impl<T> OnChargeTransaction<T> for Pallet<T>
-where
-	T: Config,
-	T::Currency: Currency<<T as frame_system::Config>::AccountId>,
-	PositiveImbalanceOf<T>: Imbalance<PalletBalanceOf<T>, Opposite = NegativeImbalanceOf<T>>,
-	NegativeImbalanceOf<T>: Imbalance<PalletBalanceOf<T>, Opposite = PositiveImbalanceOf<T>>,
-{
-	type Balance = PalletBalanceOf<T>;
-	type LiquidityInfo = Option<NegativeImbalanceOf<T>>;
-
-	/// Withdraw the predicted fee from the transaction origin.
-	///
-	/// Note: The `fee` already includes the `tip`.
-	fn withdraw_fee(
+	fn ensure_can_swap(
 		who: &T::AccountId,
-		call: &T::RuntimeCall,
-		_info: &DispatchInfoOf<T::RuntimeCall>,
-		fee: Self::Balance,
-		tip: Self::Balance,
-	) -> Result<Self::LiquidityInfo, TransactionValidityError> {
-		if fee.is_zero() {
-			return Ok(None);
+		from_currency: CurrencyId,
+		to_currency: CurrencyId,
+		amount_out: Balance,
+	) -> Result<Balance, Error<T>> {
+		// If it is other assets, go to exchange fee amount.
+		let from_asset_id =
+			Self::get_currency_asset_id(from_currency).map_err(|_| Error::<T>::ConversionError)?;
+
+		let to_asset_id =
+			Self::get_currency_asset_id(to_currency).map_err(|_| Error::<T>::ConversionError)?;
+
+		let path = vec![from_asset_id, to_asset_id];
+		match T::DexOperator::get_amount_in_by_path(amount_out, &path) {
+			Ok(amounts) => {
+				let amount_in = amounts[0];
+				T::MultiCurrency::ensure_can_withdraw(from_currency, who, amount_in)
+					.map_err(|_| Error::<T>::NotEnoughBalance)?;
+				Ok(amount_in)
+			},
+			Err(_) => Err(Error::<T>::NotEnoughBalance)?,
 		}
-
-		let withdraw_reason = if tip.is_zero() {
-			WithdrawReasons::TRANSACTION_PAYMENT
-		} else {
-			WithdrawReasons::TRANSACTION_PAYMENT | WithdrawReasons::TIP
-		};
-
-		// See if the this RuntimeCall needs to pay extra fee
-		let fee_info = T::ExtraFeeMatcher::get_fee_info(&call);
-		let (total_fee, extra_bnc_fee, fee_value, path) =
-			Self::get_extrinsic_and_extra_fee_total(call, fee)
-				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Custom(55)))?;
-
-		// Make sure there are enough BNC(extrinsic fee + extra fee) to be deducted if the user has
-		// assets in other form of tokens rather than BNC.
-		Self::ensure_can_charge_fee(who, total_fee, withdraw_reason)
-			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
-
-		if fee_info.extra_fee_name != ExtraFeeName::NoExtraFee {
-			// swap BNC for fee_currency
-			T::DexOperator::inner_swap_assets_for_exact_assets(
-				who,
-				fee_value.saturated_into(),
-				extra_bnc_fee.saturated_into(),
-				&path,
-				who,
-			)
-			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Custom(44)))?;
-
-			let transaction_extra_fee_receiver = Self::get_fee_receiver(fee_info.extra_fee_name);
-
-			T::MultiCurrency::transfer(
-				fee_info.extra_fee_currency,
-				who,
-				&transaction_extra_fee_receiver,
-				fee_value,
-			)
-			.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
-
-			// deposit extra fee deducted event
-			Self::deposit_event(Event::ExtraFeeDeducted {
-				operation: fee_info.extra_fee_name,
-				transaction_extra_fee_currency: fee_info.extra_fee_currency,
-				transaction_extra_fee_amount: fee_value,
-				transaction_extra_fee_bnc_amount: extra_bnc_fee,
-				transaction_extra_fee_receiver,
-			});
-		}
-
-		// withdraw normal extrinsic fee
-		match T::Currency::withdraw(who, fee, withdraw_reason, ExistenceRequirement::AllowDeath) {
-			Ok(imbalance) => Ok(Some(imbalance)),
-			Err(_) => Err(InvalidTransaction::Payment.into()),
-		}
-	}
-
-	/// Hand the fee and the tip over to the `[OnUnbalanced]` implementation.
-	/// Since the predicted fee might have been too high, parts of the fee may
-	/// be refunded.
-	///
-	/// Note: The `fee` already includes the `tip`.
-	fn correct_and_deposit_fee(
-		who: &T::AccountId,
-		_dispatch_info: &DispatchInfoOf<T::RuntimeCall>,
-		_post_info: &PostDispatchInfoOf<T::RuntimeCall>,
-		corrected_fee: Self::Balance,
-		tip: Self::Balance,
-		already_withdrawn: Self::LiquidityInfo,
-	) -> Result<(), TransactionValidityError> {
-		if let Some(paid) = already_withdrawn {
-			// Calculate how much refund we should return
-			let refund_amount = paid.peek().saturating_sub(corrected_fee);
-
-			// refund to the the account that paid the fees. If this fails, the
-			// account might have dropped below the existential balance. In
-			// that case we don't refund anything.
-			let refund_imbalance = T::Currency::deposit_into_existing(who, refund_amount)
-				.unwrap_or_else(|_| PositiveImbalanceOf::<T>::zero());
-			// merge the imbalance caused by paying the fees and refunding parts of it again.
-			let adjusted_paid = paid
-				.offset(refund_imbalance)
-				.same()
-				.map_err(|_| TransactionValidityError::Invalid(InvalidTransaction::Payment))?;
-			// RuntimeCall someone else to handle the imbalance (fee and tip separately)
-			let imbalances = adjusted_paid.split(tip);
-			T::OnUnbalanced::on_unbalanceds(
-				Some(imbalances.0).into_iter().chain(Some(imbalances.1)),
-			);
-		}
-		Ok(())
-	}
-}
-
-/// Provides account's fee payment asset or default fee asset ( Native asset )
-impl<T: Config> AccountFeeCurrency<T::AccountId> for Pallet<T> {
-	type Error = Error<T>;
-
-	/// Determines the appropriate currency to be used for paying transaction fees based on a
-	/// prioritized order:
-	/// 1. User's default fee currency (`UserDefaultFeeCurrency`)
-	/// 2. WETH
-	/// 3. Currencies in the `UniversalFeeCurrencyOrderList`
-	///
-	/// The method first checks if the balance of the highest-priority currency is sufficient to
-	/// cover the fee.If the balance is insufficient, it iterates through the list of currencies in
-	/// priority order.If no currency has a sufficient balance, it returns the currency with the
-	/// highest balance.
-	fn get_fee_currency(account: &T::AccountId, fee: U256) -> Result<CurrencyId, Error<T>> {
-		let fee: u128 = fee.unique_saturated_into();
-		let priority_currency = UserDefaultFeeCurrency::<T>::get(account);
-		let mut currency_list = UniversalFeeCurrencyOrderList::<T>::get();
-
-		let first_item_index = 0;
-		currency_list
-			.try_insert(first_item_index, WETH)
-			.map_err(|_| Error::<T>::MaxCurrenciesReached)?;
-
-		// When all currency balances are insufficient, return the one with the highest balance
-		let mut hopeless_currency = WETH;
-
-		if let Some(currency) = priority_currency {
-			currency_list
-				.try_insert(first_item_index, currency)
-				.map_err(|_| Error::<T>::MaxCurrenciesReached)?;
-			hopeless_currency = currency;
-		}
-
-		for maybe_currency in currency_list.iter() {
-			let comp_res = Self::cmp_with_precision(account, maybe_currency, fee, 18)?;
-
-			match comp_res {
-				Ordering::Less => {
-					// Get the currency with the highest balance
-					let hopeless_currency_balance = T::MultiCurrency::reducible_balance(
-						hopeless_currency,
-						account,
-						Preservation::Preserve,
-						Fortitude::Polite,
-					);
-					let maybe_currency_balance = T::MultiCurrency::reducible_balance(
-						*maybe_currency,
-						account,
-						Preservation::Preserve,
-						Fortitude::Polite,
-					);
-					hopeless_currency = match hopeless_currency_balance.cmp(&maybe_currency_balance)
-					{
-						Ordering::Less => *maybe_currency,
-						_ => hopeless_currency,
-					};
-					continue;
-				},
-				Ordering::Equal => return Ok(*maybe_currency),
-				Ordering::Greater => return Ok(*maybe_currency),
-			};
-		}
-
-		return Ok(hopeless_currency);
 	}
 }
 

--- a/pallets/flexible-fee/src/migrations/v2.rs
+++ b/pallets/flexible-fee/src/migrations/v2.rs
@@ -28,7 +28,7 @@ pub type UserFeeChargeOrderList<T: Config> = StorageMap<
 	Pallet<T>,
 	Twox64Concat,
 	<T as frame_system::Config>::AccountId,
-	Vec<CurrencyIdOf<T>>,
+	Vec<CurrencyId>,
 	OptionQuery,
 >;
 

--- a/pallets/flexible-fee/src/mock.rs
+++ b/pallets/flexible-fee/src/mock.rs
@@ -19,40 +19,28 @@
 #![cfg(test)]
 
 use super::*;
-use crate::{self as flexible_fee, tests::CHARLIE};
-use bifrost_asset_registry::AssetIdMaps;
-use bifrost_primitives::{
-	Balance, CurrencyId, DerivativeAccountHandler, DerivativeIndex, ExtraFeeInfo, MessageId,
-	ParaId, TokenSymbol, VTokenSupplyProvider, VKSM,
-};
-use bifrost_vtoken_voting::AccountVote;
-use bifrost_xcm_interface::traits::XcmHelper;
+use crate::{self as flexible_fee, mock_price::MockPriceFeeder};
+use bifrost_currencies::BasicCurrencyAdapter;
+use bifrost_primitives::{Balance, CurrencyId, TokenSymbol};
 use cumulus_primitives_core::ParaId as Pid;
 use frame_support::{
-	derive_impl, ord_parameter_types, parameter_types,
+	derive_impl, parameter_types,
 	sp_runtime::{DispatchError, DispatchResult},
-	traits::{ConstU128, Everything, Get, LockIdentifier, Nothing},
+	traits::{ConstU128, Get, Nothing},
 	weights::{ConstantMultiplier, IdentityFee},
 	PalletId,
 };
-use frame_system as system;
-use frame_system::{EnsureRoot, EnsureSignedBy};
+use frame_system::{self, EnsureRoot};
 use orml_traits::MultiCurrency;
 use pallet_balances::Call as BalancesCall;
-use pallet_xcm::EnsureResponse;
-use sp_arithmetic::Percent;
 use sp_runtime::{
-	testing::Header,
-	traits::{AccountIdConversion, BlockNumberProvider, IdentityLookup, UniqueSaturatedInto},
+	traits::{AccountIdConversion, IdentityLookup, UniqueSaturatedInto},
 	AccountId32, BuildStorage, SaturatedConversion,
 };
 use sp_std::marker::PhantomData;
 use std::convert::TryInto;
-use xcm::v3::MultiLocation;
-use xcm_builder::{FixedWeightBounds, FrameTransactionalProcessor};
-use xcm_executor::XcmExecutor;
 use zenlink_protocol::{
-	AssetId as ZenlinkAssetId, LocalAssetHandler, PairLpGenerate, ZenlinkMultiAssets,
+	AssetBalance, AssetId as ZenlinkAssetId, LocalAssetHandler, PairLpGenerate, ZenlinkMultiAssets,
 };
 
 pub type AccountId = AccountId32;
@@ -61,43 +49,29 @@ pub type Amount = i128;
 
 pub const TREASURY_ACCOUNT: AccountId32 = AccountId32::new([9u8; 32]);
 
-pub type Block = sp_runtime::generic::Block<Header, UncheckedExtrinsic>;
-pub type UncheckedExtrinsic = sp_runtime::generic::UncheckedExtrinsic<u32, u128, RuntimeCall, ()>;
+type Block = frame_system::mocking::MockBlock<Test>;
 
 // Configure a mock runtime to test the pallet.
 frame_support::construct_runtime!(
 	pub enum Test {
-		System: system,
+		System: frame_system,
+		Balances: pallet_balances = 10,
 		Tokens: orml_tokens,
-		Balances: pallet_balances,
 		TransactionPayment: pallet_transaction_payment,
 		FlexibleFee: flexible_fee,
 		ZenlinkProtocol: zenlink_protocol,
 		Currencies: bifrost_currencies,
-		Salp: bifrost_salp,
 		AssetRegistry: bifrost_asset_registry,
-		PolkadotXcm: pallet_xcm,
-		VtokenVoting: bifrost_vtoken_voting,
 	}
 );
 
 pub(crate) const BALANCE_TRANSFER_CALL: <Test as frame_system::Config>::RuntimeCall =
 	RuntimeCall::Balances(BalancesCall::transfer_allow_death { dest: ALICE, value: 69 });
 
-pub(crate) const SALP_CONTRIBUTE_CALL: <Test as frame_system::Config>::RuntimeCall =
-	RuntimeCall::Salp(bifrost_salp::Call::contribute { index: 2001, value: 1_000_000_000_000 });
-
-pub(crate) const VTOKENVOTING_VOTE_CALL: <Test as frame_system::Config>::RuntimeCall =
-	RuntimeCall::VtokenVoting(bifrost_vtoken_voting::Call::vote {
-		vtoken: VKSM,
-		poll_index: 1u32,
-		vtoken_vote: AccountVote::Split { aye: 1, nay: 1 },
-	});
-
 impl bifrost_asset_registry::Config for Test {
 	type RuntimeEvent = RuntimeEvent;
 	type Currency = Balances;
-	type RegisterOrigin = EnsureSignedBy<One, AccountId>;
+	type RegisterOrigin = EnsureRoot<AccountId>;
 	type WeightInfo = ();
 }
 
@@ -105,12 +79,12 @@ parameter_types! {
 	pub const BlockHashCount: u32 = 250;
 }
 
-#[derive_impl(frame_system::config_preludes::TestDefaultConfig as frame_system::DefaultConfig)]
-impl system::Config for Test {
-	type AccountData = pallet_balances::AccountData<u128>;
-	type AccountId = AccountId;
+#[derive_impl(frame_system::config_preludes::TestDefaultConfig)]
+impl frame_system::Config for Test {
 	type Block = Block;
+	type AccountId = AccountId;
 	type Lookup = IdentityLookup<Self::AccountId>;
+	type AccountData = pallet_balances::AccountData<Balance>;
 }
 
 parameter_types! {
@@ -178,20 +152,13 @@ parameter_types! {
 	pub const FlexibleFeePalletId: PalletId = PalletId(*b"bf/flexi");
 }
 
-ord_parameter_types! {
-	pub const One: AccountId = CHARLIE;
-}
-
 impl crate::Config for Test {
-	type Currency = Balances;
 	type DexOperator = ZenlinkProtocol;
 	type RuntimeEvent = RuntimeEvent;
 	type MultiCurrency = Currencies;
 	type TreasuryAccount = TreasuryAccount;
 	type MaxFeeCurrencyOrderListLen = MaxFeeCurrencyOrderListLen;
-	type OnUnbalanced = ();
 	type WeightInfo = ();
-	type ExtraFeeMatcher = ExtraFeeMatcher;
 	type ParachainId = ParaInfo;
 	type ControlOrigin = EnsureRoot<AccountId>;
 	type XcmWeightAndFeeHandler = XcmDestWeightAndFee;
@@ -200,6 +167,7 @@ impl crate::Config for Test {
 	type RelaychainCurrencyId = RelayCurrencyId;
 	type XcmRouter = ();
 	type PalletId = FlexibleFeePalletId;
+	type PriceFeeder = MockPriceFeeder;
 }
 
 pub struct XcmDestWeightAndFee;
@@ -220,24 +188,6 @@ impl XcmDestWeightAndFeeHandler<CurrencyId, Balance> for XcmDestWeightAndFee {
 	}
 }
 
-pub struct ExtraFeeMatcher;
-impl FeeGetter<RuntimeCall> for ExtraFeeMatcher {
-	fn get_fee_info(c: &RuntimeCall) -> ExtraFeeInfo {
-		match *c {
-			RuntimeCall::Salp(bifrost_salp::Call::contribute { .. }) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::SalpContribute,
-				extra_fee_currency: RelayCurrencyId::get(),
-			},
-			RuntimeCall::VtokenVoting(bifrost_vtoken_voting::Call::vote { vtoken, .. }) =>
-				ExtraFeeInfo {
-					extra_fee_name: ExtraFeeName::VoteVtoken,
-					extra_fee_currency: vtoken.to_token().unwrap_or(vtoken),
-				},
-			_ => ExtraFeeInfo::default(),
-		}
-	}
-}
-
 pub struct ParaInfo;
 impl Get<Pid> for ParaInfo {
 	fn get() -> Pid {
@@ -249,13 +199,10 @@ parameter_types! {
 	pub const GetNativeCurrencyId: CurrencyId = CurrencyId::Native(TokenSymbol::BNC);
 }
 
-pub type AdaptedBasicCurrency =
-	bifrost_currencies::BasicCurrencyAdapter<Test, Balances, Amount, BlockNumber>;
-
 impl bifrost_currencies::Config for Test {
 	type GetNativeCurrencyId = GetNativeCurrencyId;
 	type MultiCurrency = Tokens;
-	type NativeCurrency = AdaptedBasicCurrency;
+	type NativeCurrency = BasicCurrencyAdapter<Test, Balances, Amount, BlockNumber>;
 	type WeightInfo = ();
 }
 
@@ -339,196 +286,18 @@ where
 
 // Build genesis storage according to the mock runtime.
 pub(crate) fn new_test_ext() -> sp_io::TestExternalities {
-	system::GenesisConfig::<Test>::default().build_storage().unwrap().into()
-}
-
-//************** Salp mock start *****************
-
-// To control the result returned by `MockXcmExecutor`
-pub(crate) static mut MOCK_XCM_RESULT: (bool, bool) = (true, true);
-
-pub type AccountIdOf<T> = <T as frame_system::Config>::AccountId;
-
-// Mock XcmExecutor
-pub struct MockXcmExecutor;
-
-impl XcmHelper<AccountIdOf<Test>, PalletBalanceOf<Test>> for MockXcmExecutor {
-	fn contribute(
-		_contributer: AccountId,
-		_index: ParaId,
-		_value: Balance,
-	) -> Result<MessageId, DispatchError> {
-		let result = unsafe { MOCK_XCM_RESULT.0 };
-
-		match result {
-			true => Ok([0; 32]),
-			false => Err(DispatchError::BadOrigin),
-		}
-	}
+	let mut t = frame_system::GenesisConfig::<Test>::default().build_storage().unwrap();
+	// We use default for brevity, but you can configure as desired if needed.
+	pallet_balances::GenesisConfig::<Test>::default()
+		.assimilate_storage(&mut t)
+		.unwrap();
+	t.into()
 }
 
 pub const ALICE: AccountId = AccountId::new([0u8; 32]);
 
 parameter_types! {
-	pub const MinContribution: Balance = 10;
-	pub const BifrostCrowdloanId: PalletId = PalletId(*b"bf/salp#");
-	pub const RemoveKeysLimit: u32 = 50;
-	pub const SlotLength: BlockNumber = 8u32 as BlockNumber;
-	pub const LeasePeriod: BlockNumber = 8u32 as BlockNumber;
-	pub const VSBondValidPeriod: BlockNumber = 8u32 as BlockNumber;
-	pub const ReleaseCycle: BlockNumber = 8u32 as BlockNumber;
-	pub const ReleaseRatio: Percent = Percent::from_percent(50);
-	pub ConfirmMuitiSigAccount: AccountId = ALICE;
 	pub const RelayCurrencyId: CurrencyId = CurrencyId::Token(TokenSymbol::KSM);
-	pub const BuybackPalletId: PalletId = PalletId(*b"bf/salpc");
-	pub const SalpLockId: LockIdentifier = *b"salplock";
-	pub const BatchLimit: u32 = 50;
-}
-
-impl bifrost_salp::Config for Test {
-	type BancorPool = ();
-	type RuntimeEvent = RuntimeEvent;
-	type LeasePeriod = LeasePeriod;
-	type MinContribution = MinContribution;
-	type MultiCurrency = Currencies;
-	type PalletId = BifrostCrowdloanId;
-	type RelayChainToken = RelayCurrencyId;
-	type ReleaseCycle = ReleaseCycle;
-	type ReleaseRatio = ReleaseRatio;
-	type RemoveKeysLimit = RemoveKeysLimit;
-	type SlotLength = SlotLength;
-	type VSBondValidPeriod = VSBondValidPeriod;
-	type WeightInfo = ();
-	type EnsureConfirmAsGovernance = EnsureRoot<AccountId>;
-	type XcmInterface = MockXcmExecutor;
-	type TreasuryAccount = TreasuryAccount;
-	type BuybackPalletId = BuybackPalletId;
-	type DexOperator = ZenlinkProtocol;
-	type CurrencyIdConversion = AssetIdMaps<Test>;
-	type CurrencyIdRegister = AssetIdMaps<Test>;
-	type ParachainId = ParaInfo;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type StablePool = ();
-	type VtokenMinting = ();
-	type LockId = SalpLockId;
-	type BatchLimit = BatchLimit;
-}
-
-parameter_types! {
-	// One XCM operation is 200_000_000 XcmWeight, cross-chain transfer ~= 2x of transfer = 3_000_000_000
-	pub UnitWeightCost: Weight = Weight::from_parts(200_000_000, 0);
-	pub const MaxInstructions: u32 = 100;
-	pub UniversalLocation: InteriorLocation = Parachain(2001).into();
-}
-
-pub struct XcmConfig;
-impl xcm_executor::Config for XcmConfig {
-	type AssetClaims = PolkadotXcm;
-	type AssetTransactor = ();
-	type AssetTrap = PolkadotXcm;
-	type Barrier = ();
-	type RuntimeCall = RuntimeCall;
-	type IsReserve = ();
-	type IsTeleporter = ();
-	type UniversalLocation = UniversalLocation;
-	type OriginConverter = ();
-	type ResponseHandler = PolkadotXcm;
-	type SubscriptionService = PolkadotXcm;
-	type Trader = ();
-	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type XcmSender = ();
-	type PalletInstancesInfo = AllPalletsWithSystem;
-	type MaxAssetsIntoHolding = ConstU32<64>;
-	type FeeManager = ();
-	type MessageExporter = ();
-	type UniversalAliases = Nothing;
-	type CallDispatcher = RuntimeCall;
-	type SafeCallFilter = Everything;
-	type AssetLocker = ();
-	type AssetExchanger = ();
-	type Aliasers = Nothing;
-	type TransactionalProcessor = FrameTransactionalProcessor;
-	type HrmpNewChannelOpenRequestHandler = ();
-	type HrmpChannelAcceptedHandler = ();
-	type HrmpChannelClosingHandler = ();
-	type XcmRecorder = ();
-}
-
-#[cfg(feature = "runtime-benchmarks")]
-parameter_types! {
-	pub ReachableDest: Option<Location> = Some(Parent.into());
-}
-
-impl pallet_xcm::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type ExecuteXcmOrigin = xcm_builder::EnsureXcmOrigin<RuntimeOrigin, ()>;
-	type UniversalLocation = UniversalLocation;
-	type SendXcmOrigin = xcm_builder::EnsureXcmOrigin<RuntimeOrigin, ()>;
-	type Weigher = FixedWeightBounds<UnitWeightCost, RuntimeCall, MaxInstructions>;
-	type XcmExecuteFilter = Nothing;
-	type XcmExecutor = XcmExecutor<XcmConfig>;
-	type XcmReserveTransferFilter = Everything;
-	type XcmRouter = ();
-	type XcmTeleportFilter = Nothing;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	const VERSION_DISCOVERY_QUEUE_SIZE: u32 = 100;
-	type AdvertisedXcmVersion = ConstU32<2>;
-	type Currency = Balances;
-	type CurrencyMatcher = ();
-	type TrustedLockers = ();
-	type SovereignAccountOf = ();
-	type MaxLockers = ConstU32<8>;
-	type WeightInfo = pallet_xcm::TestWeightInfo;
-	type AdminOrigin = EnsureRoot<AccountId>;
-	type MaxRemoteLockConsumers = ConstU32<0>;
-	type RemoteLockConsumerIdentifier = ();
-}
-
-//************** Salp mock end *****************
-
-// ************** VtokenVoting mock start *****************
-pub struct SimpleVTokenSupplyProvider;
-
-impl VTokenSupplyProvider<CurrencyId, Balance> for SimpleVTokenSupplyProvider {
-	fn get_vtoken_supply(_: CurrencyId) -> Option<Balance> {
-		Some(u64::MAX.into())
-	}
-
-	fn get_token_supply(_: CurrencyId) -> Option<Balance> {
-		Some(u64::MAX.into())
-	}
-}
-
-parameter_types! {
-	pub const ReferendumCheckInterval: BlockNumber = 300;
-}
-
-impl bifrost_vtoken_voting::Config for Test {
-	type RuntimeEvent = RuntimeEvent;
-	type RuntimeOrigin = RuntimeOrigin;
-	type RuntimeCall = RuntimeCall;
-	type MultiCurrency = Currencies;
-	type ControlOrigin = EnsureSignedBy<One, AccountId>;
-	type ResponseOrigin = EnsureResponse<Everything>;
-	type XcmDestWeightAndFee = XcmDestWeightAndFee;
-	type DerivativeAccount = DerivativeAccount;
-	type RelaychainBlockNumberProvider = RelaychainDataProvider;
-	type VTokenSupplyProvider = SimpleVTokenSupplyProvider;
-	type MaxVotes = ConstU32<256>;
-	type ParachainId = ParaInfo;
-	type QueryTimeout = QueryTimeout;
-	type ReferendumCheckInterval = ReferendumCheckInterval;
-	type WeightInfo = ();
-}
-
-impl AccountFeeCurrency<AccountId> for Test {
-	type Error = Error<Test>;
-
-	fn get_fee_currency(account: &AccountId32, fee: U256) -> Result<CurrencyId, Self::Error> {
-		Pallet::<Test>::get_fee_currency(account, fee)
-	}
 }
 
 impl BalanceCmp<AccountId> for Test {
@@ -543,63 +312,3 @@ impl BalanceCmp<AccountId> for Test {
 		Pallet::<Test>::cmp_with_precision(account, currency, amount, amount_precision)
 	}
 }
-
-pub struct DerivativeAccount;
-impl DerivativeAccountHandler<CurrencyId, Balance> for DerivativeAccount {
-	fn check_derivative_index_exists(
-		_token: CurrencyId,
-		_derivative_index: DerivativeIndex,
-	) -> bool {
-		true
-	}
-
-	fn get_multilocation(
-		_token: CurrencyId,
-		_derivative_index: DerivativeIndex,
-	) -> Option<MultiLocation> {
-		Some(xcm::v3::Parent.into())
-	}
-
-	fn get_stake_info(
-		token: CurrencyId,
-		derivative_index: DerivativeIndex,
-	) -> Option<(Balance, Balance)> {
-		Self::get_multilocation(token, derivative_index)
-			.and_then(|_location| Some((u32::MAX.into(), u32::MAX.into())))
-	}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn init_minimums_and_maximums(_token: CurrencyId) {}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn new_delegator_ledger(_token: CurrencyId, _who: MultiLocation) {}
-
-	#[cfg(feature = "runtime-benchmarks")]
-	fn add_delegator(_token: CurrencyId, _index: DerivativeIndex, _who: MultiLocation) {}
-}
-
-parameter_types! {
-	pub static RelaychainBlockNumber: BlockNumber = 1;
-}
-
-pub struct RelaychainDataProvider;
-
-impl RelaychainDataProvider {
-	pub fn set_block_number(block: BlockNumber) {
-		RelaychainBlockNumber::set(block);
-	}
-}
-
-impl BlockNumberProvider for RelaychainDataProvider {
-	type BlockNumber = BlockNumberFor<Test>;
-
-	fn current_block_number() -> Self::BlockNumber {
-		RelaychainBlockNumber::get().into()
-	}
-}
-
-ord_parameter_types! {
-	pub const QueryTimeout: BlockNumber = 100;
-}
-
-// ************** VtokenVoting mock end *****************

--- a/pallets/flexible-fee/src/mock_price.rs
+++ b/pallets/flexible-fee/src/mock_price.rs
@@ -1,0 +1,143 @@
+// This file is part of Bifrost.
+
+// Copyright (C) Liebi Technologies PTE. LTD.
+// SPDX-License-Identifier: GPL-3.0-or-later WITH Classpath-exception-2.0
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see <https://www.gnu.org/licenses/>.
+
+#![cfg(test)]
+
+use bifrost_primitives::{
+	Balance, CurrencyId, Price, PriceDetail, PriceFeeder, BNC, DOT, DOT_U, KSM, MANTA, VDOT, VKSM,
+	WETH,
+};
+use frame_support::parameter_types;
+use sp_runtime::FixedU128;
+use std::collections::BTreeMap;
+
+parameter_types! {
+	pub static StoragePrice: BTreeMap<CurrencyId, (Price, u128)> = BTreeMap::from([
+		(BNC, (FixedU128::from_inner(200_000_000_000_000_000), 10u128.pow(12))),
+		(MANTA, (FixedU128::from_inner(800_000_000_000_000_000), 10u128.pow(18))),
+		(DOT, (FixedU128::from(5), 10u128.pow(10))),
+		(VDOT, (FixedU128::from(6), 10u128.pow(10))),
+		(DOT_U, (FixedU128::from(1), 10u128.pow(6))),
+		(KSM, (FixedU128::from(20), 10u128.pow(12))),
+		(VKSM, (FixedU128::from(25), 10u128.pow(12))),
+		(WETH, (FixedU128::from(3000), 10u128.pow(18))),
+	]);
+}
+
+pub struct MockPriceFeeder;
+impl MockPriceFeeder {
+	pub fn set_price(currency_id: CurrencyId, price: Price) {
+		let mut storage_price = StoragePrice::get();
+		match storage_price.get(&currency_id) {
+			Some((_, mantissa)) => {
+				storage_price.insert(currency_id, (price, *mantissa));
+			},
+			None => {
+				storage_price.insert(currency_id, (price, 10u128.pow(12)));
+			},
+		};
+		StoragePrice::set(storage_price);
+	}
+}
+
+impl PriceFeeder for MockPriceFeeder {
+	fn get_price(currency_id: &CurrencyId) -> Option<PriceDetail> {
+		match StoragePrice::get().get(currency_id) {
+			Some((price, _)) => Some((*price, 0)),
+			None => None,
+		}
+	}
+
+	fn get_normal_price(_asset_id: &CurrencyId) -> Option<u128> {
+		todo!()
+	}
+
+	fn get_oracle_amount_by_currency_and_amount_in(
+		currency_in: &CurrencyId,
+		amount_in: Balance,
+		currency_out: &CurrencyId,
+	) -> Option<Balance> {
+		if let Some((currency_in_price, currency_in_mantissa)) =
+			StoragePrice::get().get(&currency_in)
+		{
+			if let Some((currency_out_price, currency_out_mantissa)) =
+				StoragePrice::get().get(&currency_out)
+			{
+				let total_value = currency_in_price
+					.mul(FixedU128::from_inner(amount_in))
+					.div(FixedU128::from_inner(*currency_in_mantissa));
+				let amount_out = total_value
+					.mul(FixedU128::from_inner(*currency_out_mantissa))
+					.div(*currency_out_price);
+				return Some(amount_out.into_inner());
+			}
+		}
+		None
+	}
+}
+
+#[cfg(test)]
+mod test {
+	use super::*;
+
+	#[test]
+	fn set_price() {
+		assert_eq!(
+			MockPriceFeeder::get_price(&BNC),
+			Some((FixedU128::from_inner(200_000_000_000_000_000), 0))
+		);
+		MockPriceFeeder::set_price(BNC, FixedU128::from(100));
+		assert_eq!(MockPriceFeeder::get_price(&BNC), Some((FixedU128::from(100), 0)));
+
+		MockPriceFeeder::set_price(DOT, FixedU128::from(100));
+		assert_eq!(MockPriceFeeder::get_price(&DOT), Some((FixedU128::from(100), 0)));
+	}
+
+	#[test]
+	fn get_oracle_amount_by_currency_and_amount_in() {
+		let bnc_amount = 100 * 10u128.pow(12);
+		let dot_amount = 4 * 10u128.pow(10);
+		let ksm_amount = 1 * 10u128.pow(12);
+		let usdt_amount = 20 * 10u128.pow(6);
+		let manta_amount = 25 * 10u128.pow(18);
+		assert_eq!(
+			MockPriceFeeder::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &DOT),
+			Some(dot_amount)
+		);
+		assert_eq!(
+			MockPriceFeeder::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &DOT_U),
+			Some(usdt_amount)
+		);
+		assert_eq!(
+			MockPriceFeeder::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &KSM),
+			Some(ksm_amount)
+		);
+		assert_eq!(
+			MockPriceFeeder::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &MANTA),
+			Some(manta_amount)
+		);
+		assert_eq!(
+			MockPriceFeeder::get_oracle_amount_by_currency_and_amount_in(&DOT, dot_amount, &DOT_U),
+			Some(usdt_amount)
+		);
+		assert_eq!(
+			MockPriceFeeder::get_oracle_amount_by_currency_and_amount_in(&DOT, dot_amount, &KSM),
+			Some(ksm_amount)
+		);
+	}
+}

--- a/pallets/flexible-fee/src/tests.rs
+++ b/pallets/flexible-fee/src/tests.rs
@@ -19,155 +19,114 @@
 //! Tests for the module.
 
 #![cfg(test)]
-
-use std::cmp::Ordering::{Greater, Less};
-
+use crate::{
+	impls::on_charge_transaction::PaymentInfo, mock::*, BlockNumberFor, BoundedVec, Config,
+	DispatchError::BadOrigin, UserDefaultFeeCurrency,
+};
+use bifrost_primitives::{
+	AccountFeeCurrency, BalanceCmp, CurrencyId, TryConvertFrom, BNC, DOT, KSM, MANTA, VDOT, WETH,
+};
 use frame_support::{
 	assert_noop, assert_ok,
-	dispatch::{GetDispatchInfo, Pays, PostDispatchInfo},
-	traits::WithdrawReasons,
+	dispatch::{DispatchInfo, PostDispatchInfo},
+	traits::fungibles::Mutate,
 	weights::Weight,
 };
 use orml_traits::MultiCurrency;
 use pallet_transaction_payment::OnChargeTransaction;
-use sp_runtime::{testing::TestXt, AccountId32};
+use sp_runtime::AccountId32;
+use std::cmp::Ordering::{Greater, Less};
 use zenlink_protocol::AssetId;
-
-use bifrost_primitives::{
-	currency::WETH, AccountFeeCurrency, BalanceCmp, CurrencyId, TokenSymbol, TryConvertFrom, BNC,
-	DOT, KSM, VDOT,
-};
-
-// use balances::Call as BalancesCall;
-use crate::{
-	mock::*, BlockNumberFor, BoundedVec, Config, DispatchError::BadOrigin, UserDefaultFeeCurrency,
-};
 
 // some common variables
 pub const CHARLIE: AccountId32 = AccountId32::new([0u8; 32]);
-pub const BOB: AccountId32 = AccountId32::new([1u8; 32]);
+
 pub const ALICE: AccountId32 = AccountId32::new([2u8; 32]);
 pub const DICK: AccountId32 = AccountId32::new([3u8; 32]);
-pub const CURRENCY_ID_0: CurrencyId = BNC;
-pub const CURRENCY_ID_1: CurrencyId = CurrencyId::Stable(TokenSymbol::KUSD);
-pub const CURRENCY_ID_2: CurrencyId = DOT;
-pub const CURRENCY_ID_3: CurrencyId = VDOT;
-pub const CURRENCY_ID_4: CurrencyId = KSM;
-pub const CURRENCY_ID_5: CurrencyId = WETH;
+
+/// create a transaction info struct from weight. Handy to avoid building the whole struct.
+pub fn info() -> DispatchInfo {
+	// pays_fee: Pays::Yes -- class: DispatchClass::Normal
+	DispatchInfo { weight: Weight::default(), ..Default::default() }
+}
+
+fn post_info() -> PostDispatchInfo {
+	PostDispatchInfo { actual_weight: Some(Weight::default()), pays_fee: Default::default() }
+}
 
 fn basic_setup() {
 	// Deposit some money in Alice, Bob and Charlie's accounts.
 	// Alice
-	assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 50));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 200));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 300));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 400));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 500));
+	assert_ok!(Currencies::deposit(BNC, &ALICE, 1000 * 10u128.pow(12)));
+	assert_ok!(Currencies::deposit(DOT, &ALICE, 1000 * 10u128.pow(10)));
+	assert_ok!(Currencies::deposit(VDOT, &ALICE, 1000 * 10u128.pow(10)));
+	assert_ok!(Currencies::deposit(KSM, &ALICE, 1000 * 10u128.pow(12)));
 
-	// Bob
-	assert_ok!(Currencies::deposit(CURRENCY_ID_0, &BOB, 100));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_1, &BOB, 200));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_2, &BOB, 60));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_3, &BOB, 80));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_4, &BOB, 50));
-
-	// Charlie
-	assert_ok!(Currencies::deposit(CURRENCY_ID_0, &CHARLIE, 200));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_1, &CHARLIE, 20));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_2, &CHARLIE, 30));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_3, &CHARLIE, 40));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_4, &CHARLIE, 50));
-
-	// Dick
-	assert_ok!(Currencies::deposit(CURRENCY_ID_0, &DICK, 100000));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_1, &DICK, 100000));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_2, &DICK, 100000));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_3, &DICK, 100000));
-	assert_ok!(Currencies::deposit(CURRENCY_ID_4, &DICK, 100000));
+	assert_ok!(Currencies::deposit(BNC, &DICK, 1000 * 10u128.pow(12)));
+	assert_ok!(Currencies::deposit(DOT, &DICK, 1000 * 10u128.pow(10)));
+	assert_ok!(Currencies::deposit(VDOT, &DICK, 1000 * 10u128.pow(10)));
+	assert_ok!(Currencies::deposit(KSM, &DICK, 1000 * 10u128.pow(12)));
 
 	// create DEX pair
 	let para_id: u32 = 2001;
-	let asset_0_currency_id: AssetId = AssetId::try_convert_from(CURRENCY_ID_0, para_id).unwrap();
-	let asset_1_currency_id: AssetId = AssetId::try_convert_from(CURRENCY_ID_1, para_id).unwrap();
-	let asset_2_currency_id: AssetId = AssetId::try_convert_from(CURRENCY_ID_2, para_id).unwrap();
-	let asset_3_currency_id: AssetId = AssetId::try_convert_from(CURRENCY_ID_3, para_id).unwrap();
-	let asset_4_currency_id: AssetId = AssetId::try_convert_from(CURRENCY_ID_4, para_id).unwrap();
+	let bnc_asset_id: AssetId = AssetId::try_convert_from(BNC, para_id).unwrap();
+	let dot_asset_id: AssetId = AssetId::try_convert_from(DOT, para_id).unwrap();
+	let vdot_asset_id: AssetId = AssetId::try_convert_from(VDOT, para_id).unwrap();
+	let ksm_asset_id: AssetId = AssetId::try_convert_from(KSM, para_id).unwrap();
 
 	assert_ok!(ZenlinkProtocol::create_pair(
 		RuntimeOrigin::root(),
-		asset_0_currency_id,
-		asset_1_currency_id,
-		ALICE
+		bnc_asset_id,
+		dot_asset_id,
+		DICK
 	));
 
 	assert_ok!(ZenlinkProtocol::create_pair(
 		RuntimeOrigin::root(),
-		asset_0_currency_id,
-		asset_2_currency_id,
-		ALICE
+		bnc_asset_id,
+		vdot_asset_id,
+		DICK
 	));
 
 	assert_ok!(ZenlinkProtocol::create_pair(
 		RuntimeOrigin::root(),
-		asset_0_currency_id,
-		asset_3_currency_id,
-		ALICE
+		bnc_asset_id,
+		ksm_asset_id,
+		DICK
 	));
 
-	assert_ok!(ZenlinkProtocol::create_pair(
-		RuntimeOrigin::root(),
-		asset_0_currency_id,
-		asset_4_currency_id,
-		ALICE
-	));
-
-	let mut deadline: BlockNumberFor<Test> =
+	let deadline: BlockNumberFor<Test> =
 		<frame_system::Pallet<Test>>::block_number() + BlockNumberFor::<Test>::from(100u32);
-	assert_ok!(ZenlinkProtocol::add_liquidity(
-		RuntimeOrigin::signed(DICK),
-		asset_0_currency_id,
-		asset_1_currency_id,
-		1000,
-		1000,
-		1,
-		1,
-		deadline
-	));
 
 	// pool 0 2
-	deadline = <frame_system::Pallet<Test>>::block_number() + BlockNumberFor::<Test>::from(100u32);
 	assert_ok!(ZenlinkProtocol::add_liquidity(
 		RuntimeOrigin::signed(DICK),
-		asset_0_currency_id,
-		asset_2_currency_id,
-		1000,
-		1000,
+		bnc_asset_id,
+		dot_asset_id,
+		100 * 10u128.pow(12),
+		100 * 10u128.pow(10),
 		1,
 		1,
 		deadline
 	));
 
-	// pool 0 3
-	deadline = <frame_system::Pallet<Test>>::block_number() + BlockNumberFor::<Test>::from(100u32);
 	assert_ok!(ZenlinkProtocol::add_liquidity(
 		RuntimeOrigin::signed(DICK),
-		asset_0_currency_id,
-		asset_3_currency_id,
-		1000,
-		1000,
+		bnc_asset_id,
+		vdot_asset_id,
+		100 * 10u128.pow(12),
+		100 * 10u128.pow(10),
 		1,
 		1,
 		deadline
 	));
 
-	// pool 0 4
-	deadline = <frame_system::Pallet<Test>>::block_number() + BlockNumberFor::<Test>::from(100u32);
 	assert_ok!(ZenlinkProtocol::add_liquidity(
 		RuntimeOrigin::signed(DICK),
-		asset_0_currency_id,
-		asset_4_currency_id,
-		1000,
-		1000,
+		bnc_asset_id,
+		ksm_asset_id,
+		100 * 10u128.pow(12),
+		100 * 10u128.pow(12),
 		1,
 		1,
 		deadline
@@ -180,11 +139,11 @@ fn set_user_default_fee_currency_should_work() {
 		let origin_signed_alice = RuntimeOrigin::signed(ALICE);
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(
 			origin_signed_alice.clone(),
-			Some(CURRENCY_ID_0)
+			Some(BNC)
 		));
 
 		let alice_default_currency = UserDefaultFeeCurrency::<Test>::get(ALICE).unwrap();
-		assert_eq!(alice_default_currency, CURRENCY_ID_0);
+		assert_eq!(alice_default_currency, BNC);
 
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(origin_signed_alice.clone(), None));
 		assert_eq!(UserDefaultFeeCurrency::<Test>::get(ALICE).is_none(), true);
@@ -192,28 +151,21 @@ fn set_user_default_fee_currency_should_work() {
 }
 
 #[test]
-fn set_universal_fee_currency_order_list_should_work() {
+fn set_default_fee_currency_list_should_work() {
 	new_test_ext().execute_with(|| {
 		let asset_order_list_vec: BoundedVec<
 			CurrencyId,
 			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![
-			CURRENCY_ID_4,
-			CURRENCY_ID_3,
-			CURRENCY_ID_2,
-			CURRENCY_ID_1,
-			CURRENCY_ID_0,
-		])
-		.unwrap();
+		> = BoundedVec::try_from(vec![KSM, VDOT, DOT, BNC]).unwrap();
 		assert_noop!(
-			FlexibleFee::set_universal_fee_currency_order_list(
+			FlexibleFee::set_default_fee_currency_list(
 				RuntimeOrigin::signed(CHARLIE),
 				asset_order_list_vec.clone()
 			),
 			BadOrigin
 		);
 
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
 			RuntimeOrigin::root(),
 			asset_order_list_vec.clone()
 		));
@@ -223,324 +175,177 @@ fn set_universal_fee_currency_order_list_should_work() {
 }
 
 #[test]
-fn inner_get_user_fee_charge_order_list_should_work() {
+fn ensure_can_swap() {
 	new_test_ext().execute_with(|| {
-		let asset_order_list_bounded_vec: BoundedVec<
-			CurrencyId,
-			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![
-			CURRENCY_ID_4,
-			CURRENCY_ID_3,
-			CURRENCY_ID_2,
-			CURRENCY_ID_1,
-			CURRENCY_ID_0,
-		])
-		.unwrap();
+		basic_setup();
+		assert_ok!(FlexibleFee::ensure_can_swap(&ALICE, BNC, DOT, 10));
+	})
+}
 
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
-			RuntimeOrigin::root(),
-			asset_order_list_bounded_vec.clone(),
+#[test]
+fn withdraw_fee() {
+	new_test_ext().execute_with(|| {
+		basic_setup();
+		assert_ok!(FlexibleFee::set_user_default_fee_currency(
+			RuntimeOrigin::signed(ALICE),
+			Some(BNC)
 		));
-
-		let mut asset_order_list_vec = asset_order_list_bounded_vec.into_iter().collect::<Vec<_>>();
 		assert_eq!(
-			FlexibleFee::inner_get_user_fee_charge_order_list(&ALICE),
-			asset_order_list_vec.clone()
+			FlexibleFee::withdraw_fee(
+				&ALICE,
+				&BALANCE_TRANSFER_CALL,
+				&info(),
+				100 * 10u128.pow(12),
+				0
+			)
+			.unwrap(),
+			Some(PaymentInfo::Native(100 * 10u128.pow(12)))
 		);
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 900 * 10u128.pow(12));
 
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(
 			RuntimeOrigin::signed(ALICE),
-			Some(CURRENCY_ID_0),
+			Some(DOT)
 		));
-
-		let mut new_list = Vec::new();
-		new_list.push(CURRENCY_ID_0);
-		new_list.append(&mut asset_order_list_vec);
-
-		assert_eq!(FlexibleFee::inner_get_user_fee_charge_order_list(&ALICE), new_list);
-	});
-}
-
-#[test]
-fn ensure_can_charge_fee_should_work() {
-	new_test_ext().execute_with(|| {
-		basic_setup();
-		let origin_signed_bob = RuntimeOrigin::signed(BOB);
-		let asset_order_list_vec: BoundedVec<
-			CurrencyId,
-			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![
-			CURRENCY_ID_4,
-			CURRENCY_ID_3,
-			CURRENCY_ID_2,
-			CURRENCY_ID_1,
-			CURRENCY_ID_0,
-		])
-		.unwrap();
-
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
-			RuntimeOrigin::root(),
-			asset_order_list_vec.clone()
-		));
-
-		// Alice's default fee currency is Asset 1
-		let _ = FlexibleFee::set_user_default_fee_currency(
-			RuntimeOrigin::signed(ALICE),
-			Some(CURRENCY_ID_1),
+		assert_eq!(
+			FlexibleFee::withdraw_fee(
+				&ALICE,
+				&BALANCE_TRANSFER_CALL,
+				&info(),
+				100 * 10u128.pow(12),
+				0
+			)
+			.unwrap(),
+			Some(PaymentInfo::NonNative(4 * 10u128.pow(10), DOT))
 		);
+		assert_eq!(Currencies::free_balance(DOT, &ALICE), 996 * 10u128.pow(10));
+	})
+}
 
-		// Bob's default fee currency is Asset 0
-		let _ = FlexibleFee::set_user_default_fee_currency(
-			origin_signed_bob.clone(),
-			Some(CURRENCY_ID_0),
+#[test]
+fn withdraw_fee_with_universal_fee_currency() {
+	new_test_ext().execute_with(|| {
+		basic_setup();
+		let fee = 100 * 10u128.pow(12);
+		let info = info();
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
+			RuntimeOrigin::root(),
+			BoundedVec::try_from(vec![BNC, DOT, MANTA]).unwrap()
+		));
+
+		assert_eq!(
+			FlexibleFee::withdraw_fee(&ALICE, &BALANCE_TRANSFER_CALL, &info, fee, 0).unwrap(),
+			Some(PaymentInfo::Native(fee))
 		);
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 900 * 10u128.pow(12));
 
-		// Alice originally should have 50 Asset 0 and 200 Asset 1
-		// Now that 50 < 100, so Alice should be deducted some amount from Asset 1 and get 100 Asset
-		// 0
-		assert_ok!(FlexibleFee::ensure_can_charge_fee(
-			&ALICE,
-			100,
-			WithdrawReasons::TRANSACTION_PAYMENT,
-		));
-
-		// Alice should be deducted 100 from Asset 1 since Asset 0 doesn't have enough balance.
-		// asset1 : 200-112=88 asset0: 50+100 = 150
-		assert_eq!(Currencies::total_balance(CURRENCY_ID_0, &ALICE), 150);
-		assert_eq!(Currencies::total_balance(CURRENCY_ID_1, &ALICE), 88);
-
-		// Currency 0 is the native currency.
-		assert_eq!(<Test as crate::Config>::Currency::free_balance(&ALICE), 150);
-
-		// Bob originally should have 100 Asset 0 and 200 Asset 1
-		assert_ok!(FlexibleFee::ensure_can_charge_fee(
-			&BOB,
-			100,
-			WithdrawReasons::TRANSACTION_PAYMENT,
-		));
-		assert_eq!(<Test as crate::Config>::Currency::free_balance(&BOB), 100); // no exitential deposit requirement. 100 is enough
-																		// Bob should be deducted 100 from Asset 0 since Asset 0 has enough balance.
-																		// Currency 1 should not be affected.
-		assert_eq!(Currencies::total_balance(CURRENCY_ID_1, &BOB), 200);
-	});
+		Currencies::set_balance(BNC, &ALICE, 0u128);
+		assert_eq!(
+			FlexibleFee::withdraw_fee(&ALICE, &BALANCE_TRANSFER_CALL, &info, fee, 0).unwrap(),
+			Some(PaymentInfo::NonNative(4 * 10u128.pow(10), DOT))
+		);
+		assert_eq!(Currencies::free_balance(DOT, &ALICE), 996 * 10u128.pow(10));
+	})
 }
 
 #[test]
-fn find_out_fee_currency_and_amount_should_work() {
+fn withdraw_extra_fee() {
 	new_test_ext().execute_with(|| {
 		basic_setup();
-
-		// set universal fee currency order list
-		let asset_order_list_vec: BoundedVec<
-			CurrencyId,
-			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![
-			CURRENCY_ID_4,
-			CURRENCY_ID_3,
-			CURRENCY_ID_2,
-			CURRENCY_ID_1,
-			CURRENCY_ID_0,
-		])
-		.unwrap();
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		let fee = 100 * 10u128.pow(12);
+		let info = info();
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
 			RuntimeOrigin::root(),
-			asset_order_list_vec.clone()
+			BoundedVec::try_from(vec![BNC, DOT, MANTA]).unwrap()
 		));
 
-		// charlie originally has 200 currency 0(Native currency)
-		let (fee_token, amount_in, amount_out) =
-			FlexibleFee::find_out_fee_currency_and_amount(&CHARLIE, 88).unwrap().unwrap();
-		assert_eq!(fee_token, CURRENCY_ID_0);
-		assert_eq!(amount_in, 88);
-		assert_eq!(amount_out, 88);
-
-		// alice originally should have 50 Asset 0. Should use Currency 4 to pay fee.
-		let (fee_token, amount_in, amount_out) =
-			FlexibleFee::find_out_fee_currency_and_amount(&ALICE, 88).unwrap().unwrap();
-		assert_eq!(fee_token, CURRENCY_ID_4);
-		assert_eq!(amount_in, 97);
-		assert_eq!(amount_out, 88);
-	});
-}
-
-#[test]
-fn get_extrinsic_and_extra_fee_total_should_work() {
-	new_test_ext().execute_with(|| {
-		basic_setup();
-
-		let native_asset_id = FlexibleFee::get_currency_asset_id(CURRENCY_ID_0).unwrap();
-		let asset_id = FlexibleFee::get_currency_asset_id(CURRENCY_ID_4).unwrap();
-
-		// call with no extra fee
-		let path_vec = vec![native_asset_id, native_asset_id];
-		let (total_fee, extra_bnc_fee, fee_value, path) =
-			FlexibleFee::get_extrinsic_and_extra_fee_total(&BALANCE_TRANSFER_CALL, 88).unwrap();
-		assert_eq!(total_fee, 88);
-		assert_eq!(extra_bnc_fee, 0);
-		assert_eq!(fee_value, 0);
-		assert_eq!(path, path_vec);
-
-		//  salp contribuite call with extra fee
-		let path_vec = vec![native_asset_id, asset_id];
-		let (total_fee, extra_bnc_fee, fee_value, path) =
-			FlexibleFee::get_extrinsic_and_extra_fee_total(&SALP_CONTRIBUTE_CALL, 88).unwrap();
-		assert_eq!(total_fee, 200);
-		assert_eq!(extra_bnc_fee, 112);
-		assert_eq!(fee_value, 100);
-		assert_eq!(path, path_vec);
-
-		// vtoken-voting vote call with extra fee
-		let path_vec = vec![native_asset_id, asset_id];
-		let (total_fee, extra_bnc_fee, fee_value, path) =
-			FlexibleFee::get_extrinsic_and_extra_fee_total(&VTOKENVOTING_VOTE_CALL, 88).unwrap();
-		assert_eq!(total_fee, 200);
-		assert_eq!(extra_bnc_fee, 112);
-		assert_eq!(fee_value, 100);
-		assert_eq!(path, path_vec);
-	});
-}
-
-#[test]
-fn cal_fee_token_and_amount_should_work() {
-	new_test_ext().execute_with(|| {
-		basic_setup();
-
-		// set universal fee currency order list
-		let asset_order_list_vec: BoundedVec<
-			CurrencyId,
-			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![
-			CURRENCY_ID_4,
-			CURRENCY_ID_3,
-			CURRENCY_ID_2,
-			CURRENCY_ID_1,
-			CURRENCY_ID_0,
-		])
-		.unwrap();
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		assert_ok!(FlexibleFee::set_extra_fee(
 			RuntimeOrigin::root(),
-			asset_order_list_vec.clone()
+			BoundedVec::try_from(vec![10, 0]).unwrap(),
+			Some((DOT, 1_000_000_000, DICK))
 		));
 
-		// use default asset_order_list_vec
-		let (currency_id, amount_in) =
-			FlexibleFee::cal_fee_token_and_amount(&ALICE, 20, &BALANCE_TRANSFER_CALL).unwrap();
-		assert_eq!(currency_id, CURRENCY_ID_4);
-		assert_eq!(amount_in, 21);
-
-		// set alice's default fee currency to be CURRENCY_ID_0
-		assert_ok!(FlexibleFee::set_user_default_fee_currency(
-			RuntimeOrigin::signed(ALICE),
-			Some(CURRENCY_ID_0),
-		));
-
-		// alice has enough balance of CURRENCY_ID_0, so should use CURRENCY_ID_0 to pay fee
-		let (currency_id, amount_in) =
-			FlexibleFee::cal_fee_token_and_amount(&ALICE, 20, &BALANCE_TRANSFER_CALL).unwrap();
-		assert_eq!(currency_id, CURRENCY_ID_0);
-		assert_eq!(amount_in, 20);
-
-		// alice originally only have 50 CURRENCY_ID_0. Should use Currency 4 to pay fee.
-		let (currency_id, amount_in) =
-			FlexibleFee::cal_fee_token_and_amount(&ALICE, 88, &SALP_CONTRIBUTE_CALL).unwrap();
-		assert_eq!(currency_id, CURRENCY_ID_4);
-		assert_eq!(amount_in, 251);
-	});
-}
-
-#[test]
-fn withdraw_fee_should_work() {
-	new_test_ext().execute_with(|| {
-		basic_setup();
-
-		let call = RuntimeCall::FlexibleFee(crate::Call::set_user_default_fee_currency {
-			maybe_fee_currency: Some(CURRENCY_ID_0),
-		});
-
-		// prepare info variable
-		let extra = ();
-		let xt = TestXt::new(call.clone(), Some((0u64, extra)));
-		let info = xt.get_dispatch_info();
-
-		// 99 inclusion fee and a tip of 8
-		assert_ok!(FlexibleFee::withdraw_fee(&CHARLIE, &call, &info, 107, 8));
-
-		assert_eq!(<Test as crate::Config>::Currency::free_balance(&CHARLIE), 93);
-	});
+		assert_eq!(
+			FlexibleFee::withdraw_fee(&ALICE, &BALANCE_TRANSFER_CALL, &info, fee, 0).unwrap(),
+			Some(PaymentInfo::Native(fee))
+		);
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 899899598695987);
+	})
 }
 
 #[test]
 fn correct_and_deposit_fee_should_work() {
 	new_test_ext().execute_with(|| {
 		basic_setup();
-		let call = RuntimeCall::FlexibleFee(crate::Call::set_user_default_fee_currency {
-			maybe_fee_currency: Some(CURRENCY_ID_0),
-		});
-		// prepare info variable
-		let extra = ();
-		let xt = TestXt::new(call.clone(), Some((0u64, extra)));
-		let info = xt.get_dispatch_info();
 
-		// prepare post info
-		let post_info = PostDispatchInfo {
-			actual_weight: Some(Weight::from_parts(20, 0)),
-			pays_fee: Pays::Yes,
-		};
+		let corrected_fee = 5 * 10u128.pow(12);
+		let tip = 0;
 
-		let corrected_fee = 80;
-		let tip = 8;
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 1000 * 10u128.pow(12));
 
-		let already_withdrawn = FlexibleFee::withdraw_fee(&CHARLIE, &call, &info, 107, 8).unwrap();
-
-		assert_eq!(<Test as crate::Config>::Currency::free_balance(&CHARLIE), 93);
-
+		let already_withdrawn = Some(PaymentInfo::Native(10 * 10u128.pow(12)));
 		assert_ok!(FlexibleFee::correct_and_deposit_fee(
-			&CHARLIE,
-			&info,
-			&post_info,
+			&ALICE,
+			&info(),
+			&post_info(),
 			corrected_fee,
 			tip,
 			already_withdrawn
 		));
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 1005 * 10u128.pow(12));
 
-		assert_eq!(<Test as crate::Config>::Currency::free_balance(&CHARLIE), 120);
+		let corrected_fee = 10 * 10u128.pow(12);
+		let tip = 0;
+		assert_eq!(Currencies::free_balance(DOT, &ALICE), 1000 * 10u128.pow(10));
+
+		let already_withdrawn = Some(PaymentInfo::NonNative(1 * 10u128.pow(10), DOT));
+		assert_ok!(FlexibleFee::correct_and_deposit_fee(
+			&ALICE,
+			&info(),
+			&post_info(),
+			corrected_fee,
+			tip,
+			already_withdrawn
+		));
+		assert_eq!(Currencies::free_balance(DOT, &ALICE), 10006 * 10u128.pow(9));
 	});
 }
 
 #[test]
-fn deduct_salp_fee_should_work() {
+fn correct_and_deposit_fee_with_tip() {
 	new_test_ext().execute_with(|| {
 		basic_setup();
 
-		// prepare info variable
-		let extra = ();
-		let xt = TestXt::new(SALP_CONTRIBUTE_CALL.clone(), Some((0u64, extra)));
-		let info = xt.get_dispatch_info();
+		let corrected_fee = 5 * 10u128.pow(12);
+		let tip = 5 * 10u128.pow(12);
 
-		// 80 inclusion fee and a tip of 8
-		assert_ok!(FlexibleFee::withdraw_fee(&CHARLIE, &SALP_CONTRIBUTE_CALL, &info, 80, 8));
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 1000 * 10u128.pow(12));
 
-		// originally Charlie has 200 currency 0(Native currency)
-		// 200 - 88 = 112. extra fee cost 104. 112 - 104 = 8
-		assert_eq!(<Test as crate::Config>::Currency::free_balance(&CHARLIE), 8);
+		let already_withdrawn = Some(PaymentInfo::Native(10 * 10u128.pow(12)));
+		assert_ok!(FlexibleFee::correct_and_deposit_fee(
+			&ALICE,
+			&info(),
+			&post_info(),
+			corrected_fee,
+			tip,
+			already_withdrawn
+		));
+		assert_eq!(Currencies::free_balance(BNC, &ALICE), 1005 * 10u128.pow(12));
 
-		// Other currencies should not be affected
-		assert_eq!(
-			<Test as crate::Config>::MultiCurrency::free_balance(CURRENCY_ID_1, &CHARLIE),
-			20
-		);
-		assert_eq!(
-			<Test as crate::Config>::MultiCurrency::free_balance(CURRENCY_ID_2, &CHARLIE),
-			30
-		);
-		assert_eq!(
-			<Test as crate::Config>::MultiCurrency::free_balance(CURRENCY_ID_3, &CHARLIE),
-			40
-		);
-		assert_eq!(
-			<Test as crate::Config>::MultiCurrency::free_balance(CURRENCY_ID_4, &CHARLIE),
-			50
-		);
+		let corrected_fee = 10 * 10u128.pow(12);
+		let tip = 10 * 10u128.pow(12);
+		assert_eq!(Currencies::free_balance(DOT, &ALICE), 1000 * 10u128.pow(10));
+
+		let already_withdrawn = Some(PaymentInfo::NonNative(1 * 10u128.pow(10), DOT));
+		assert_ok!(FlexibleFee::correct_and_deposit_fee(
+			&ALICE,
+			&info(),
+			&post_info(),
+			corrected_fee,
+			tip,
+			already_withdrawn
+		));
+		assert_eq!(Currencies::free_balance(DOT, &ALICE), 10006 * 10u128.pow(9));
 	});
 }
 
@@ -548,12 +353,12 @@ fn deduct_salp_fee_should_work() {
 fn get_currency_asset_id_should_work() {
 	new_test_ext().execute_with(|| {
 		// BNC
-		let asset_id = FlexibleFee::get_currency_asset_id(CURRENCY_ID_0).unwrap();
+		let asset_id = FlexibleFee::get_currency_asset_id(BNC).unwrap();
 		let bnc_asset_id = AssetId { chain_id: 2001, asset_type: 0, asset_index: 0 };
 		assert_eq!(asset_id, bnc_asset_id);
 
 		// KSM
-		let asset_id = FlexibleFee::get_currency_asset_id(CURRENCY_ID_4).unwrap();
+		let asset_id = FlexibleFee::get_currency_asset_id(KSM).unwrap();
 		let ksm_asset_id = AssetId { chain_id: 2001, asset_type: 2, asset_index: 516 };
 		assert_eq!(asset_id, ksm_asset_id);
 	});
@@ -565,21 +370,16 @@ fn get_fee_currency_should_work_with_default_currency() {
 		let origin_signed_alice = RuntimeOrigin::signed(ALICE);
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(
 			origin_signed_alice.clone(),
-			Some(CURRENCY_ID_0)
+			Some(BNC)
 		));
 
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 100u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 100u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 100u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 100u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 100u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 100u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 100u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 100u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 100u128.pow(18))); // ETH
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, BNC);
 	});
 }
@@ -590,21 +390,16 @@ fn get_fee_currency_should_work_with_default_currency_poor() {
 		let origin_signed_alice = RuntimeOrigin::signed(ALICE);
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(
 			origin_signed_alice.clone(),
-			Some(CURRENCY_ID_0)
+			Some(BNC)
 		));
 
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 1u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 100u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 100u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 100u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 100u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 1u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 100u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 100u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 100u128.pow(18))); // ETH
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, WETH);
 	});
 }
@@ -612,18 +407,13 @@ fn get_fee_currency_should_work_with_default_currency_poor() {
 #[test]
 fn get_fee_currency_should_work_with_weth() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 100u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 100u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 100u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 100u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 100u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 100u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 100u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 100u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 100u128.pow(18))); // ETH
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, WETH);
 	});
 }
@@ -631,28 +421,23 @@ fn get_fee_currency_should_work_with_weth() {
 #[test]
 fn get_fee_currency_should_work_with_weth_poor() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 100u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 100u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 100u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 100u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 1u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 100u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 100u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 100u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 1u128.pow(18))); // ETH
 
 		let asset_order_list_vec: BoundedVec<
 			CurrencyId,
 			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![CURRENCY_ID_3, CURRENCY_ID_2, CURRENCY_ID_0]).unwrap();
+		> = BoundedVec::try_from(vec![VDOT, DOT, BNC]).unwrap();
 
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
 			RuntimeOrigin::root(),
 			asset_order_list_vec.clone()
 		));
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, VDOT);
 	});
 }
@@ -663,31 +448,26 @@ fn get_fee_currency_should_work_with_universal_fee_currency() {
 		let origin_signed_alice = RuntimeOrigin::signed(ALICE);
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(
 			origin_signed_alice.clone(),
-			Some(CURRENCY_ID_0)
+			Some(BNC)
 		));
 
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 1u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 100u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 100u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 100u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 1u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 1u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 100u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 100u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 1u128.pow(18))); // ETH
 
 		let asset_order_list_vec: BoundedVec<
 			CurrencyId,
 			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![CURRENCY_ID_3, CURRENCY_ID_2, CURRENCY_ID_0]).unwrap();
+		> = BoundedVec::try_from(vec![VDOT, DOT, BNC]).unwrap();
 
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
 			RuntimeOrigin::root(),
 			asset_order_list_vec.clone()
 		));
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, VDOT);
 	});
 }
@@ -695,28 +475,23 @@ fn get_fee_currency_should_work_with_universal_fee_currency() {
 #[test]
 fn get_fee_currency_should_work_with_universal_fee_currency_poor() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 1u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 100u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 100u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 1u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 1u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 1u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 100u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 1u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 100u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 1u128.pow(18))); // ETH
 
 		let asset_order_list_vec: BoundedVec<
 			CurrencyId,
 			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![CURRENCY_ID_3, CURRENCY_ID_2, CURRENCY_ID_0]).unwrap();
+		> = BoundedVec::try_from(vec![VDOT, DOT, BNC]).unwrap();
 
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
 			RuntimeOrigin::root(),
 			asset_order_list_vec.clone()
 		));
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, DOT);
 	});
 }
@@ -727,31 +502,26 @@ fn get_fee_currency_should_work_with_all_currency_poor() {
 		let origin_signed_alice = RuntimeOrigin::signed(ALICE);
 		assert_ok!(FlexibleFee::set_user_default_fee_currency(
 			origin_signed_alice.clone(),
-			Some(CURRENCY_ID_0)
+			Some(BNC)
 		));
 
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 7u128.pow(12))); // BNC
-		assert_ok!(Currencies::deposit(CURRENCY_ID_1, &ALICE, 6u128.pow(18))); // KUSD CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 5u128.pow(10))); // DOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_3, &ALICE, 4u128.pow(10))); // vDOT
-		assert_ok!(Currencies::deposit(CURRENCY_ID_4, &ALICE, 3u128.pow(12))); // KSM CurrencyNotSupport
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 2u128.pow(18))); // ETH
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 7u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 5u128.pow(10))); // DOT
+		assert_ok!(Currencies::deposit(VDOT, &ALICE, 4u128.pow(10))); // vDOT
+		assert_ok!(Currencies::deposit(KSM, &ALICE, 3u128.pow(12))); // KSM CurrencyNotSupport
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 2u128.pow(18))); // ETH
 
 		let asset_order_list_vec: BoundedVec<
 			CurrencyId,
 			<Test as Config>::MaxFeeCurrencyOrderListLen,
-		> = BoundedVec::try_from(vec![CURRENCY_ID_3, CURRENCY_ID_2, CURRENCY_ID_0]).unwrap();
+		> = BoundedVec::try_from(vec![VDOT, DOT, BNC]).unwrap();
 
-		assert_ok!(FlexibleFee::set_universal_fee_currency_order_list(
+		assert_ok!(FlexibleFee::set_default_fee_currency_list(
 			RuntimeOrigin::root(),
 			asset_order_list_vec.clone()
 		));
 
-		let currency = <Test as AccountFeeCurrency<AccountId>>::get_fee_currency(
-			&ALICE,
-			10u128.pow(18).into(),
-		)
-		.unwrap();
+		let currency = FlexibleFee::get_fee_currency(&ALICE, 10u128.pow(18).into()).unwrap();
 		assert_eq!(currency, BNC);
 	});
 }
@@ -759,15 +529,10 @@ fn get_fee_currency_should_work_with_all_currency_poor() {
 #[test]
 fn cmp_with_precision_should_work_with_weth() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Currencies::deposit(CURRENCY_ID_5, &ALICE, 10u128.pow(18) - 1)); // ETH
+		assert_ok!(Currencies::deposit(WETH, &ALICE, 10u128.pow(18) - 1)); // ETH
 
-		let ordering = <Test as BalanceCmp<AccountId>>::cmp_with_precision(
-			&ALICE,
-			&WETH,
-			10u128.pow(18),
-			18u32,
-		)
-		.unwrap();
+		let ordering =
+			FlexibleFee::cmp_with_precision(&ALICE, &WETH, 10u128.pow(18), 18u32).unwrap();
 		assert_eq!(ordering, Less);
 	});
 }
@@ -775,15 +540,10 @@ fn cmp_with_precision_should_work_with_weth() {
 #[test]
 fn cmp_with_precision_should_work_with_dot() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Currencies::deposit(CURRENCY_ID_2, &ALICE, 10u128.pow(11) + 1)); // DOT
+		assert_ok!(Currencies::deposit(DOT, &ALICE, 10u128.pow(11) + 1)); // DOT
 
-		let ordering = <Test as BalanceCmp<AccountId>>::cmp_with_precision(
-			&ALICE,
-			&DOT,
-			10u128.pow(18),
-			18u32,
-		)
-		.unwrap();
+		let ordering =
+			FlexibleFee::cmp_with_precision(&ALICE, &DOT, 10u128.pow(18), 18u32).unwrap();
 		assert_eq!(ordering, Greater);
 	});
 }
@@ -791,15 +551,10 @@ fn cmp_with_precision_should_work_with_dot() {
 #[test]
 fn cmp_with_precision_should_work_with_bnc() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Currencies::deposit(CURRENCY_ID_0, &ALICE, 11u128.pow(12))); // BNC
+		assert_ok!(Currencies::deposit(BNC, &ALICE, 11u128.pow(12))); // BNC
 
-		let ordering = <Test as BalanceCmp<AccountId>>::cmp_with_precision(
-			&ALICE,
-			&BNC,
-			10u128.pow(18),
-			18u32,
-		)
-		.unwrap();
+		let ordering =
+			FlexibleFee::cmp_with_precision(&ALICE, &BNC, 10u128.pow(18), 18u32).unwrap();
 		assert_eq!(ordering, Greater);
 	});
 }

--- a/pallets/flexible-fee/src/tests.rs
+++ b/pallets/flexible-fee/src/tests.rs
@@ -34,6 +34,7 @@ use frame_support::{
 };
 use orml_traits::MultiCurrency;
 use pallet_transaction_payment::OnChargeTransaction;
+use sp_arithmetic::FixedU128;
 use sp_runtime::AccountId32;
 use std::cmp::Ordering::{Greater, Less};
 use zenlink_protocol::AssetId;
@@ -216,7 +217,12 @@ fn withdraw_fee() {
 				0
 			)
 			.unwrap(),
-			Some(PaymentInfo::NonNative(4 * 10u128.pow(10), DOT))
+			Some(PaymentInfo::NonNative(
+				4 * 10u128.pow(10),
+				DOT,
+				FixedU128::from_inner(200_000_000_000_000_000),
+				FixedU128::from(5)
+			))
 		);
 		assert_eq!(Currencies::free_balance(DOT, &ALICE), 996 * 10u128.pow(10));
 	})
@@ -242,7 +248,12 @@ fn withdraw_fee_with_universal_fee_currency() {
 		Currencies::set_balance(BNC, &ALICE, 0u128);
 		assert_eq!(
 			FlexibleFee::withdraw_fee(&ALICE, &BALANCE_TRANSFER_CALL, &info, fee, 0).unwrap(),
-			Some(PaymentInfo::NonNative(4 * 10u128.pow(10), DOT))
+			Some(PaymentInfo::NonNative(
+				4 * 10u128.pow(10),
+				DOT,
+				FixedU128::from_inner(200_000_000_000_000_000),
+				FixedU128::from(5)
+			))
 		);
 		assert_eq!(Currencies::free_balance(DOT, &ALICE), 996 * 10u128.pow(10));
 	})
@@ -298,7 +309,12 @@ fn correct_and_deposit_fee_should_work() {
 		let tip = 0;
 		assert_eq!(Currencies::free_balance(DOT, &ALICE), 1000 * 10u128.pow(10));
 
-		let already_withdrawn = Some(PaymentInfo::NonNative(1 * 10u128.pow(10), DOT));
+		let already_withdrawn = Some(PaymentInfo::NonNative(
+			1 * 10u128.pow(10),
+			DOT,
+			FixedU128::from_inner(200_000_000_000_000_000),
+			FixedU128::from(5),
+		));
 		assert_ok!(FlexibleFee::correct_and_deposit_fee(
 			&ALICE,
 			&info(),
@@ -336,7 +352,12 @@ fn correct_and_deposit_fee_with_tip() {
 		let tip = 10 * 10u128.pow(12);
 		assert_eq!(Currencies::free_balance(DOT, &ALICE), 1000 * 10u128.pow(10));
 
-		let already_withdrawn = Some(PaymentInfo::NonNative(1 * 10u128.pow(10), DOT));
+		let already_withdrawn = Some(PaymentInfo::NonNative(
+			1 * 10u128.pow(10),
+			DOT,
+			FixedU128::from_inner(200_000_000_000_000_000),
+			FixedU128::from(5),
+		));
 		assert_ok!(FlexibleFee::correct_and_deposit_fee(
 			&ALICE,
 			&info(),

--- a/pallets/flexible-fee/src/weights.rs
+++ b/pallets/flexible-fee/src/weights.rs
@@ -54,7 +54,7 @@ use sp_std::marker::PhantomData;
 /// Weight functions needed for bifrost_flexible_fee.
 pub trait WeightInfo {
 	fn set_user_default_fee_currency() -> Weight;
-	fn set_universal_fee_currency_order_list() -> Weight;
+	fn set_default_fee_currency_list() -> Weight;
 }
 
 // For backwards compatibility and tests
@@ -71,7 +71,7 @@ impl WeightInfo for () {
 	}
 	/// Storage: FlexibleFee UniversalFeeCurrencyOrderList (r:0 w:1)
 	/// Proof Skipped: FlexibleFee UniversalFeeCurrencyOrderList (max_values: Some(1), max_size: None, mode: Measured)
-	fn set_universal_fee_currency_order_list() -> Weight {
+	fn set_default_fee_currency_list() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/pallets/lend-market/src/lib.rs
+++ b/pallets/lend-market/src/lib.rs
@@ -26,7 +26,7 @@ use core::cmp::max;
 
 pub use crate::rate_model::*;
 use bifrost_primitives::{
-	Balance, CurrencyId, Liquidity, Price, Rate, Ratio, Shortfall, Timestamp,
+	Balance, CurrencyId, Liquidity, Price, PriceFeeder, Rate, Ratio, Shortfall, Timestamp,
 };
 use frame_support::{
 	pallet_prelude::*,
@@ -43,7 +43,7 @@ use num_traits::cast::ToPrimitive;
 pub use pallet::*;
 use pallet_traits::{
 	ConvertToBigUint, LendMarket as LendMarketTrait, LendMarketMarketDataProvider,
-	LendMarketPositionDataProvider, MarketInfo, MarketStatus, PriceFeeder,
+	LendMarketPositionDataProvider, MarketInfo, MarketStatus,
 };
 use sp_runtime::{
 	traits::{

--- a/pallets/lend-market/src/mock.rs
+++ b/pallets/lend-market/src/mock.rs
@@ -259,11 +259,21 @@ impl PriceFeeder for MockPriceFeeder {
 		todo!()
 	}
 
+	fn get_amount_by_prices(
+		_currency_in: &CurrencyId,
+		_amount_in: Balance,
+		_currency_in_price: Price,
+		_currency_out: &CurrencyId,
+		_currency_out_price: Price,
+	) -> Option<Balance> {
+		todo!()
+	}
+
 	fn get_oracle_amount_by_currency_and_amount_in(
 		_currency_in: &CurrencyId,
 		_amount_in: Balance,
 		_currency_out: &CurrencyId,
-	) -> Option<Balance> {
+	) -> Option<(Balance, Price, Price)> {
 		todo!()
 	}
 }

--- a/pallets/leverage-staking/src/lib.rs
+++ b/pallets/leverage-staking/src/lib.rs
@@ -40,7 +40,7 @@ use frame_support::{
 use frame_system::{ensure_signed, pallet_prelude::*};
 pub use pallet_traits::{
 	ConvertToBigUint, LendMarket as LendMarketTrait, LendMarketMarketDataProvider,
-	LendMarketPositionDataProvider, MarketInfo, MarketStatus, PriceFeeder,
+	LendMarketPositionDataProvider, MarketInfo, MarketStatus,
 };
 pub use parity_scale_codec::{Decode, Encode};
 use sp_runtime::{

--- a/pallets/leverage-staking/src/mock.rs
+++ b/pallets/leverage-staking/src/mock.rs
@@ -423,11 +423,21 @@ impl PriceFeeder for MockPriceFeeder {
 		todo!()
 	}
 
+	fn get_amount_by_prices(
+		_currency_in: &CurrencyId,
+		_amount_in: Balance,
+		_currency_in_price: Price,
+		_currency_out: &CurrencyId,
+		_currency_out_price: Price,
+	) -> Option<Balance> {
+		todo!()
+	}
+
 	fn get_oracle_amount_by_currency_and_amount_in(
 		_currency_in: &CurrencyId,
 		_amount_in: Balance,
 		_currency_out: &CurrencyId,
-	) -> Option<Balance> {
+	) -> Option<(Balance, Price, Price)> {
 		todo!()
 	}
 }

--- a/pallets/leverage-staking/src/mock.rs
+++ b/pallets/leverage-staking/src/mock.rs
@@ -22,7 +22,7 @@ use bifrost_asset_registry::AssetIdMaps;
 pub use bifrost_primitives::{
 	currency::*, Balance, CurrencyId, CurrencyIdMapping, SlpOperator, SlpxOperator, TokenSymbol,
 };
-use bifrost_primitives::{Moment, MoonbeamChainId, Price, PriceDetail, Ratio};
+use bifrost_primitives::{Moment, MoonbeamChainId, Price, PriceDetail, PriceFeeder, Ratio};
 use bifrost_runtime_common::milli;
 use frame_support::{
 	derive_impl, ord_parameter_types, parameter_types,

--- a/pallets/prices/src/lib.rs
+++ b/pallets/prices/src/lib.rs
@@ -24,7 +24,8 @@
 
 use bifrost_asset_registry::AssetMetadata;
 use bifrost_primitives::{
-	Balance, CurrencyId, CurrencyIdMapping, Price, PriceDetail, TimeStampedPrice, TokenInfo,
+	Balance, CurrencyId, CurrencyIdMapping, Price, PriceDetail, PriceFeeder, TimeStampedPrice,
+	TokenInfo,
 };
 use frame_support::{dispatch::DispatchClass, pallet_prelude::*, transactional};
 use frame_system::pallet_prelude::*;

--- a/pallets/prices/src/tests.rs
+++ b/pallets/prices/src/tests.rs
@@ -236,17 +236,29 @@ fn get_oracle_amount_by_currency_and_amount_in() {
 		let bnc_amount = 100 * 10u128.pow(12);
 		// 0.2 DOT
 		assert_eq!(
-			Some(2_000_000_000),
+			Some((
+				2_000_000_000,
+				Price::from_inner(200_000_000_000_000_000),
+				Price::saturating_from_integer(100)
+			)),
 			Prices::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &DOT)
 		);
 		// 0.04 KSM
 		assert_eq!(
-			Some(40_000_000_000),
+			Some((
+				40_000_000_000,
+				Price::from_inner(200_000_000_000_000_000),
+				Price::saturating_from_integer(500)
+			)),
 			Prices::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &KSM)
 		);
 		// 33.33333333333333333333
 		assert_eq!(
-			Some(33_333_333_333_333_333_333),
+			Some((
+				33_333_333_333_333_333_333,
+				Price::from_inner(200_000_000_000_000_000),
+				Price::from_inner(600_000_000_000_000_000)
+			)),
 			Prices::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &MANTA)
 		);
 
@@ -254,17 +266,29 @@ fn get_oracle_amount_by_currency_and_amount_in() {
 		let bnc_amount = 10u128.pow(10);
 		// 0.00002 DOT * 100 =  0.002 U
 		assert_eq!(
-			Some(200_000),
+			Some((
+				200_000,
+				Price::from_inner(200_000_000_000_000_000),
+				Price::saturating_from_integer(100)
+			)),
 			Prices::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &DOT)
 		);
 		// 0.000004 KSM * 500 = 0.002 U
 		assert_eq!(
-			Some(4_000_000),
+			Some((
+				4_000_000,
+				Price::from_inner(200_000_000_000_000_000),
+				Price::saturating_from_integer(500)
+			)),
 			Prices::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &KSM)
 		);
 		// 0.003333333333333333333333 MANTA
 		assert_eq!(
-			Some(3_333_333_333_333_333),
+			Some((
+				3_333_333_333_333_333,
+				Price::from_inner(200_000_000_000_000_000),
+				Price::from_inner(600_000_000_000_000_000)
+			)),
 			Prices::get_oracle_amount_by_currency_and_amount_in(&BNC, bnc_amount, &MANTA)
 		);
 	});

--- a/pallets/traits/src/lib.rs
+++ b/pallets/traits/src/lib.rs
@@ -1,6 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 
-use bifrost_primitives::{Balance, CurrencyId, PriceDetail};
 use num_bigint::{BigUint, ToBigUint};
 
 pub mod evm;
@@ -10,16 +9,6 @@ pub use lend_market::*;
 
 pub trait EmergencyCallFilter<Call> {
 	fn contains(call: &Call) -> bool;
-}
-
-pub trait PriceFeeder {
-	fn get_price(asset_id: &CurrencyId) -> Option<PriceDetail>;
-	fn get_normal_price(asset_id: &CurrencyId) -> Option<u128>;
-	fn get_oracle_amount_by_currency_and_amount_in(
-		currency_in: &CurrencyId,
-		amount_in: Balance,
-		currency_out: &CurrencyId,
-	) -> Option<Balance>;
 }
 
 pub trait EmergencyPriceFeeder<CurrencyId, Price> {

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -35,6 +35,9 @@ pub mod xcm;
 pub use crate::xcm::*;
 pub mod mock_xcm;
 pub use crate::mock_xcm::*;
+
+pub mod price;
+pub use crate::price::*;
 pub mod salp;
 pub use salp::*;
 pub mod traits;
@@ -153,18 +156,6 @@ pub type DerivativeIndex = u16;
 
 pub type TimeStampedPrice = orml_oracle::TimestampedValue<Price, Moment>;
 
-#[derive(
-	Encode, Decode, Eq, PartialEq, Copy, Clone, RuntimeDebug, PartialOrd, Ord, scale_info::TypeInfo,
-)]
-pub enum ExtraFeeName {
-	SalpContribute,
-	StatemineTransfer,
-	VoteVtoken,
-	VoteRemoveDelegatorVote,
-	NoExtraFee,
-	EthereumTransfer,
-}
-
 // For vtoken-minting
 #[derive(
 	PartialEq, Eq, Clone, Encode, Decode, MaxEncodedLen, RuntimeDebug, scale_info::TypeInfo,
@@ -220,18 +211,4 @@ pub enum XcmOperationType {
 	SupplementaryFee,
 	EthereumTransfer,
 	TeleportAssets,
-}
-
-pub struct ExtraFeeInfo {
-	pub extra_fee_name: ExtraFeeName,
-	pub extra_fee_currency: CurrencyId,
-}
-
-impl Default for ExtraFeeInfo {
-	fn default() -> Self {
-		Self {
-			extra_fee_name: ExtraFeeName::NoExtraFee,
-			extra_fee_currency: CurrencyId::Native(TokenSymbol::BNC),
-		}
-	}
 }

--- a/primitives/src/price.rs
+++ b/primitives/src/price.rs
@@ -16,14 +16,21 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-use crate::{Balance, CurrencyId, PriceDetail};
+use crate::{Balance, CurrencyId, Price, PriceDetail};
 
 pub trait PriceFeeder {
 	fn get_price(asset_id: &CurrencyId) -> Option<PriceDetail>;
 	fn get_normal_price(asset_id: &CurrencyId) -> Option<u128>;
+	fn get_amount_by_prices(
+		currency_in: &CurrencyId,
+		amount_in: Balance,
+		currency_in_price: Price,
+		currency_out: &CurrencyId,
+		currency_out_price: Price,
+	) -> Option<Balance>;
 	fn get_oracle_amount_by_currency_and_amount_in(
 		currency_in: &CurrencyId,
 		amount_in: Balance,
 		currency_out: &CurrencyId,
-	) -> Option<Balance>;
+	) -> Option<(Balance, Price, Price)>;
 }

--- a/primitives/src/price.rs
+++ b/primitives/src/price.rs
@@ -16,28 +16,14 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <https://www.gnu.org/licenses/>.
 
-#![cfg(feature = "runtime-benchmarks")]
+use crate::{Balance, CurrencyId, PriceDetail};
 
-use frame_benchmarking::v1::{benchmarks, whitelisted_caller};
-use frame_support::BoundedVec;
-
-use bifrost_primitives::{CurrencyId, TokenSymbol};
-use frame_system::RawOrigin;
-use sp_std::vec;
-
-use crate::{Call, Config, Pallet};
-
-benchmarks! {
-	set_user_default_fee_currency {
-		let caller = whitelisted_caller();
-	}: _(RawOrigin::Signed(caller),Some(CurrencyId::Token(TokenSymbol::DOT)))
-
-	set_default_fee_currency_list {
-		let default_list = BoundedVec::try_from(vec![CurrencyId::Token(TokenSymbol::DOT)]).unwrap();
-	}: _(RawOrigin::Root,default_list)
-
-	impl_benchmark_test_suite!(
-	Pallet,
-	crate::mock::new_test_ext(),
-	crate::mock::Test)
+pub trait PriceFeeder {
+	fn get_price(asset_id: &CurrencyId) -> Option<PriceDetail>;
+	fn get_normal_price(asset_id: &CurrencyId) -> Option<u128>;
+	fn get_oracle_amount_by_currency_and_amount_in(
+		currency_in: &CurrencyId,
+		amount_in: Balance,
+		currency_out: &CurrencyId,
+	) -> Option<Balance>;
 }

--- a/primitives/src/traits.rs
+++ b/primitives/src/traits.rs
@@ -21,8 +21,8 @@
 #![allow(clippy::unnecessary_cast)]
 
 use crate::{
-	AssetIds, CurrencyId, DerivativeIndex, ExtraFeeInfo, LeasePeriod, ParaId, PoolId, RedeemType,
-	TokenId, TokenSymbol, XcmOperationType,
+	AssetIds, CurrencyId, DerivativeIndex, LeasePeriod, ParaId, PoolId, RedeemType, TokenId,
+	TokenSymbol, XcmOperationType,
 };
 use frame_support::pallet_prelude::{DispatchResultWithPostInfo, Weight};
 use parity_scale_codec::{Decode, Encode, FullCodec};
@@ -455,10 +455,6 @@ where
 	) -> DispatchResult {
 		Ok(())
 	}
-}
-
-pub trait FeeGetter<RuntimeCall> {
-	fn get_fee_info(call: &RuntimeCall) -> ExtraFeeInfo;
 }
 
 pub trait DerivativeAccountHandler<CurrencyId, Balance> {

--- a/runtime/bifrost-kusama/src/lib.rs
+++ b/runtime/bifrost-kusama/src/lib.rs
@@ -72,12 +72,12 @@ use bifrost_asset_registry::AssetIdMaps;
 
 pub use bifrost_primitives::{
 	traits::{
-		CheckSubAccount, FarmingInfo, FeeGetter, VtokenMintingInterface, VtokenMintingOperator,
+		CheckSubAccount, FarmingInfo, VtokenMintingInterface, VtokenMintingOperator,
 		XcmDestWeightAndFeeHandler,
 	},
 	AccountId, Amount, AssetIds, Balance, BlockNumber, CurrencyId, CurrencyIdMapping,
-	DistributionId, ExtraFeeInfo, ExtraFeeName, Liquidity, Moment, ParaId, PoolId, Price, Rate,
-	Ratio, RpcContributionStatus, Shortfall, TimeUnit, TokenSymbol,
+	DistributionId, Liquidity, Moment, ParaId, PoolId, Price, Rate, Ratio, RpcContributionStatus,
+	Shortfall, TimeUnit, TokenSymbol,
 };
 pub use bifrost_runtime_common::{
 	cent, constants::time::*, dollar, micro, milli, millicent, AuraId, CouncilCollective,
@@ -1021,51 +1021,17 @@ impl bifrost_vesting::Config for Runtime {
 
 // Bifrost modules start
 
-pub struct ExtraFeeMatcher;
-impl FeeGetter<RuntimeCall> for ExtraFeeMatcher {
-	fn get_fee_info(c: &RuntimeCall) -> ExtraFeeInfo {
-		match *c {
-			RuntimeCall::Salp(bifrost_salp::Call::contribute { .. }) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::SalpContribute,
-				extra_fee_currency: RelayCurrencyId::get(),
-			},
-			RuntimeCall::XcmInterface(bifrost_xcm_interface::Call::transfer_statemine_assets {
-				..
-			}) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::StatemineTransfer,
-				extra_fee_currency: RelayCurrencyId::get(),
-			},
-			RuntimeCall::VtokenVoting(bifrost_vtoken_voting::Call::vote { vtoken, .. }) =>
-				ExtraFeeInfo {
-					extra_fee_name: ExtraFeeName::VoteVtoken,
-					extra_fee_currency: vtoken.to_token().unwrap_or(vtoken),
-				},
-			RuntimeCall::VtokenVoting(bifrost_vtoken_voting::Call::remove_delegator_vote {
-				vtoken,
-				..
-			}) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::VoteRemoveDelegatorVote,
-				extra_fee_currency: vtoken.to_token().unwrap_or(vtoken),
-			},
-			_ => ExtraFeeInfo::default(),
-		}
-	}
-}
-
 parameter_types! {
 	pub MaxFeeCurrencyOrderListLen: u32 = 50;
 }
 
 impl bifrost_flexible_fee::Config for Runtime {
-	type Currency = Balances;
 	type DexOperator = ZenlinkProtocol;
 	type RuntimeEvent = RuntimeEvent;
 	type MultiCurrency = Currencies;
 	type TreasuryAccount = BifrostTreasuryAccount;
 	type MaxFeeCurrencyOrderListLen = MaxFeeCurrencyOrderListLen;
-	type OnUnbalanced = Treasury;
 	type WeightInfo = weights::bifrost_flexible_fee::BifrostWeight<Runtime>;
-	type ExtraFeeMatcher = ExtraFeeMatcher;
 	type ParachainId = ParachainInfo;
 	type ControlOrigin = TechAdminOrCouncil;
 	type XcmWeightAndFeeHandler = XcmInterface;
@@ -1074,6 +1040,7 @@ impl bifrost_flexible_fee::Config for Runtime {
 	type RelaychainCurrencyId = RelayCurrencyId;
 	type XcmRouter = XcmRouter;
 	type PalletId = FlexibleFeePalletId;
+	type PriceFeeder = Prices;
 }
 
 parameter_types! {

--- a/runtime/bifrost-kusama/src/weights/bifrost_flexible_fee.rs
+++ b/runtime/bifrost-kusama/src/weights/bifrost_flexible_fee.rs
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> bifrost_flexible_fee::WeightInfo for BifrostWeight
 	}
 	// Storage: FlexibleFee UniversalFeeCurrencyOrderList (r:0 w:1)
 	// Proof Skipped: FlexibleFee UniversalFeeCurrencyOrderList (max_values: Some(1), max_size: None, mode: Measured)
-	fn set_universal_fee_currency_order_list() -> Weight {
+	fn set_default_fee_currency_list() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/runtime/bifrost-polkadot/src/lib.rs
+++ b/runtime/bifrost-polkadot/src/lib.rs
@@ -73,13 +73,12 @@ use bb_bnc::traits::BbBNCInterface;
 use bifrost_asset_registry::{AssetIdMaps, FixedRateOfAsset};
 pub use bifrost_primitives::{
 	traits::{
-		CheckSubAccount, FarmingInfo, FeeGetter, VtokenMintingInterface, VtokenMintingOperator,
+		CheckSubAccount, FarmingInfo, VtokenMintingInterface, VtokenMintingOperator,
 		XcmDestWeightAndFeeHandler,
 	},
 	AccountId, Amount, AssetIds, Balance, BlockNumber, CurrencyId, CurrencyIdMapping,
-	DistributionId, ExtraFeeInfo, ExtraFeeName, Liquidity, Moment, Nonce, ParaId, PoolId, Price,
-	Rate, Ratio, RpcContributionStatus, Shortfall, TimeUnit, TokenSymbol, DOT_TOKEN_ID,
-	GLMR_TOKEN_ID,
+	DistributionId, Liquidity, Moment, Nonce, ParaId, PoolId, Price, Rate, Ratio,
+	RpcContributionStatus, Shortfall, TimeUnit, TokenSymbol, DOT_TOKEN_ID, GLMR_TOKEN_ID,
 };
 use bifrost_runtime_common::{
 	constants::time::*, dollar, micro, milli, AuraId, CouncilCollective,
@@ -907,57 +906,17 @@ impl bifrost_vesting::Config for Runtime {
 
 // Bifrost modules start
 
-pub struct ExtraFeeMatcher;
-impl FeeGetter<RuntimeCall> for ExtraFeeMatcher {
-	fn get_fee_info(c: &RuntimeCall) -> ExtraFeeInfo {
-		match *c {
-			RuntimeCall::Salp(bifrost_salp::Call::contribute { .. }) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::SalpContribute,
-				extra_fee_currency: RelayCurrencyId::get(),
-			},
-			RuntimeCall::XcmInterface(bifrost_xcm_interface::Call::transfer_statemine_assets {
-				..
-			}) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::StatemineTransfer,
-				extra_fee_currency: RelayCurrencyId::get(),
-			},
-			RuntimeCall::XcmInterface(bifrost_xcm_interface::Call::transfer_ethereum_assets {
-				..
-			}) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::EthereumTransfer,
-				extra_fee_currency: RelayCurrencyId::get(),
-			},
-			RuntimeCall::VtokenVoting(bifrost_vtoken_voting::Call::vote { vtoken, .. }) =>
-				ExtraFeeInfo {
-					extra_fee_name: ExtraFeeName::VoteVtoken,
-					extra_fee_currency: vtoken.to_token().unwrap_or(vtoken),
-				},
-			RuntimeCall::VtokenVoting(bifrost_vtoken_voting::Call::remove_delegator_vote {
-				vtoken,
-				..
-			}) => ExtraFeeInfo {
-				extra_fee_name: ExtraFeeName::VoteRemoveDelegatorVote,
-				extra_fee_currency: vtoken.to_token().unwrap_or(vtoken),
-			},
-			_ => ExtraFeeInfo::default(),
-		}
-	}
-}
-
 parameter_types! {
 	pub MaxFeeCurrencyOrderListLen: u32 = 50;
 }
 
 impl bifrost_flexible_fee::Config for Runtime {
-	type Currency = Balances;
 	type DexOperator = ZenlinkProtocol;
 	type RuntimeEvent = RuntimeEvent;
 	type MultiCurrency = Currencies;
 	type TreasuryAccount = BifrostTreasuryAccount;
 	type MaxFeeCurrencyOrderListLen = MaxFeeCurrencyOrderListLen;
-	type OnUnbalanced = Treasury;
 	type WeightInfo = weights::bifrost_flexible_fee::BifrostWeight<Runtime>;
-	type ExtraFeeMatcher = ExtraFeeMatcher;
 	type ParachainId = ParachainInfo;
 	type ControlOrigin = TechAdminOrCouncil;
 	type XcmWeightAndFeeHandler = XcmInterface;
@@ -966,6 +925,7 @@ impl bifrost_flexible_fee::Config for Runtime {
 	type RelaychainCurrencyId = RelayCurrencyId;
 	type XcmRouter = XcmRouter;
 	type PalletId = FlexibleFeePalletId;
+	type PriceFeeder = Prices;
 }
 
 parameter_types! {

--- a/runtime/bifrost-polkadot/src/weights/bifrost_flexible_fee.rs
+++ b/runtime/bifrost-polkadot/src/weights/bifrost_flexible_fee.rs
@@ -66,7 +66,7 @@ impl<T: frame_system::Config> bifrost_flexible_fee::WeightInfo for BifrostWeight
 	}
 	// Storage: FlexibleFee UniversalFeeCurrencyOrderList (r:0 w:1)
 	// Proof Skipped: FlexibleFee UniversalFeeCurrencyOrderList (max_values: Some(1), max_size: None, mode: Measured)
-	fn set_universal_fee_currency_order_list() -> Weight {
+	fn set_default_fee_currency_list() -> Weight {
 		// Proof Size summary in bytes:
 		//  Measured:  `0`
 		//  Estimated: `0`

--- a/runtime/common/src/price.rs
+++ b/runtime/common/src/price.rs
@@ -28,9 +28,9 @@ use sp_std::marker::PhantomData;
 use xcm::latest::Weight;
 
 use bifrost_primitives::{
-	AccountFeeCurrency, AccountFeeCurrencyBalanceInCurrency, Balance, CurrencyId, PriceProvider,
+	AccountFeeCurrency, AccountFeeCurrencyBalanceInCurrency, Balance, CurrencyId, PriceFeeder,
+	PriceProvider,
 };
-use pallet_traits::PriceFeeder;
 
 use crate::Ratio;
 


### PR DESCRIPTION
### Changes
1. Remove redundant code.
2. Support for dynamically adding call for charging additional fees. `set_extra_fee`.
3. Calculating BNC and other Token exchange rates using Oracal price data. `get_oracle_amount_by_currency_and_amount_in`