### PR TITLE
add bootnodes to bifrost-polkadot.json

### DIFF
--- a/node/service/res/bifrost-polkadot.json
+++ b/node/service/res/bifrost-polkadot.json
@@ -6,7 +6,8 @@
     "/dns4/jp.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWHaTVz5iv5jvWaT5WaJWxV5bP4VQXNUN8uvJCQnKMW5Gg",
     "/dns4/hk.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWA3Vz7a9kCF4qv7sukd3AGySwxzS98zTGVft1oHjW5enm",
     "/dns4/eu.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWJLuZb3ZTSiCr35QaNVTrxtjB5FjNWXWWTUEEt7vvGtyz",
-    "/dns4/us.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWHo4jh4YUptet3dDRRdfMLpZmynebu75FF2NQWyVMwp3f"
+    "/dns4/us.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWHo4jh4YUptet3dDRRdfMLpZmynebu75FF2NQWyVMwp3f",
+    "/dns/bifrost-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWAcMntMyMx1CZctumvVBTyJ28MambrX3dw5i8aFCo8xNv"
   ],
   "telemetryEndpoints": [
     [

--- a/node/service/res/bifrost-polkadot.json
+++ b/node/service/res/bifrost-polkadot.json
@@ -7,7 +7,8 @@
     "/dns4/hk.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWA3Vz7a9kCF4qv7sukd3AGySwxzS98zTGVft1oHjW5enm",
     "/dns4/eu.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWJLuZb3ZTSiCr35QaNVTrxtjB5FjNWXWWTUEEt7vvGtyz",
     "/dns4/us.bifrost-polkadot.liebi.com/tcp/30333/p2p/12D3KooWHo4jh4YUptet3dDRRdfMLpZmynebu75FF2NQWyVMwp3f",
-    "/dns/bifrost-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWAcMntMyMx1CZctumvVBTyJ28MambrX3dw5i8aFCo8xNv"
+    "/dns/bifrost-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWAcMntMyMx1CZctumvVBTyJ28MambrX3dw5i8aFCo8xNv",
+    "/dns/bifrost-polkadot-boot-ng.dwellir.com/tcp/30365/p2p/12D3KooWAcMntMyMx1CZctumvVBTyJ28MambrX3dw5i8aFCo8xNv"
   ],
   "telemetryEndpoints": [
     [


### PR DESCRIPTION
New bifrost polkadot parachain bootnode, verify with:
```
<bifrost-binary> --chain=bifrost-polkadot --reserved-only --reserved-nodes=/dns/bifrost-polkadot-boot-ng.dwellir.com/tcp/443/wss/p2p/12D3KooWAcMntMyMx1CZctumvVBTyJ28MambrX3dw5i8aFCo8xNv
```
```
<bifrost-binary> --chain=bifrost-polkadot --reserved-only --reserved-nodes=/dns/bifrost-polkadot-boot-ng.dwellir.com/tcp/30365/p2p/12D3KooWAcMntMyMx1CZctumvVBTyJ28MambrX3dw5i8aFCo8xNv
```