### PR TITLE
fix: 🐛 add RateAdjustmentLimited

### DIFF
--- a/pallets/stable-asset/src/lib.rs
+++ b/pallets/stable-asset/src/lib.rs
@@ -346,7 +346,7 @@ pub mod pallet {
 	use super::{PoolTokenIndex, StableAssetPoolId, StableAssetPoolInfo};
 	use crate::{
 		traits::{StableAsset, ValidateAssetId},
-		WeightInfo,
+		WeightInfo, U256,
 	};
 	use frame_support::{
 		dispatch::DispatchResult, pallet_prelude::*, traits::EnsureOrigin, transactional, PalletId,
@@ -667,6 +667,9 @@ pub mod pallet {
 			/// The pool id.
 			pool_id: StableAssetPoolId,
 		},
+		/// Rate adjustment was limited by hardcap
+		/// Parameters: [pool_id, vtoken, current_rate, target_rate, adjusted_rate]
+		RateAdjustmentLimited(StableAssetPoolId, T::AssetId, U256, U256, U256),
 	}
 
 	#[pallet::error]

--- a/pallets/stable-pool/src/lib.rs
+++ b/pallets/stable-pool/src/lib.rs
@@ -461,16 +461,46 @@ impl<T: Config> Pallet<T> {
 			let old_price = U256::from(fee_denominator)
 				.checked_mul(numerator_u256)?
 				.checked_div(demoninator_u256)?;
-			// Skip if the new price is less than old price.
-			if new_price <= delta.checked_add(old_price)? && new_price > old_price {
+
+			// Skip if the new price is less than or equal to old price
+			if new_price <= old_price {
+				return Some(());
+			}
+
+			// Calculate maximum allowed price
+			let max_allowed_price = delta.checked_add(old_price)?;
+
+			if new_price <= max_allowed_price {
+				// Case 1: Price change is within hardcap - proceed normally
 				return bifrost_stable_asset::Pallet::<T>::set_token_rate(
 					pool_id,
 					sp_std::vec![(vtoken, (vtoken_issuance, token_pool_amount))],
 				)
 				.ok();
-			} else if new_price == old_price {
-				// Do not update token rate or emit failed event if the price is the same.
-				return Some(());
+			} else {
+				// Case 2: Price change exceeds hardcap - adjust to maximum allowed
+				let adjusted_token_pool_amount = max_allowed_price
+					.checked_mul(U256::from(vtoken_issuance.saturated_into::<u128>()))?
+					.checked_div(U256::from(fee_denominator))?
+					.saturated_into::<u128>();
+
+				// Emit event for hardcap limitation
+				bifrost_stable_asset::Pallet::<T>::deposit_event(
+					bifrost_stable_asset::Event::<T>::RateAdjustmentLimited(
+						pool_id,
+						vtoken,
+						old_price,
+						new_price,
+						max_allowed_price,
+					),
+				);
+
+				// Update rate to maximum allowed value
+				return bifrost_stable_asset::Pallet::<T>::set_token_rate(
+					pool_id,
+					sp_std::vec![(vtoken, (vtoken_issuance, adjusted_token_pool_amount.into()))],
+				)
+				.ok();
 			}
 		}
 		None

--- a/pallets/stable-pool/src/mock.rs
+++ b/pallets/stable-pool/src/mock.rs
@@ -19,8 +19,8 @@ use crate as bifrost_stable_pool;
 use bifrost_asset_registry::AssetIdMaps;
 pub use bifrost_primitives::{
 	currency::{MOVR, VMOVR},
-	Balance, CurrencyId, CurrencyIdMapping, SlpOperator, SlpxOperator, TokenSymbol, ASTR, BNC, DOT,
-	GLMR, VBNC, VDOT,
+	Balance, CurrencyId, CurrencyIdMapping, SlpxOperator, TokenSymbol, ASTR, BNC, DOT, GLMR, VBNC,
+	VDOT,
 };
 use bifrost_primitives::{
 	BifrostEntranceAccount, BifrostExitAccount, IncentivePoolAccount, MoonbeamChainId,

--- a/pallets/stable-pool/src/tests.rs
+++ b/pallets/stable-pool/src/tests.rs
@@ -1134,41 +1134,97 @@ fn over_the_hardcap_should_not_work() {
 			assert_ok!(StablePool::config_vtoken_auto_refresh(
 				RuntimeOrigin::root(),
 				VDOT,
-				Permill::from_percent(10)
+				Permill::from_percent(5)
 			));
+			let initial_amount = 1_000_000_u128;
 			assert_ok!(StablePool::edit_token_rate(
 				RuntimeOrigin::root(),
 				0,
-				vec![(coin0, (1, 1)), (coin1, (1, 1))]
+				vec![
+					(coin0, (initial_amount, initial_amount)),
+					(coin1, (initial_amount, initial_amount))
+				]
 			));
 
 			assert_ok!(<Test as crate::Config>::VtokenMinting::increase_token_pool(
 				DOT, 20_000_000
 			));
 			assert_ok!(StablePool::on_swap(&3u128, 0, 0, 1, 5000000u128, 0));
+			// Verify that token rates remained within hardcap
+			let rates: Vec<_> =
+				bifrost_stable_asset::TokenRateCaches::<Test>::iter_prefix(0).collect();
+
+			// Check if rates changed but stayed within hardcap (5%)
+			for (asset, (issuance, amount)) in &rates {
+				if *asset == coin1 {
+					// Calculate max allowed change (5% of initial_amount)
+					let max_increase = initial_amount
+						.saturating_add(initial_amount.saturating_mul(5).saturating_div(100));
+
+					// Calculate current rate (amount/issuance)
+					let current_rate = amount
+						.saturating_mul(initial_amount)
+						.saturating_div(*issuance);
+
+					// Assert current rate is within bounds
+					assert!(
+						current_rate <= max_increase,
+						"Rate change exceeded hardcap of 5%. Current: {}, Max allowed: {}",
+						current_rate,
+						max_increase
+					);
+				}
+			}
+
+			// Verify there are still two token rates
+			assert_eq!(rates.len(), 2, "Expected two token rates to exist");
+
 			assert_eq!(
 				bifrost_stable_asset::TokenRateCaches::<Test>::iter_prefix(0).collect::<Vec<(
 					AssetIdOf<Test>,
 					(AtLeast64BitUnsignedOf<Test>, AtLeast64BitUnsignedOf<Test>),
 				)>>(),
-				vec![(coin0, (1, 1)), (coin1, (1, 1))]
+				vec![
+					(coin0, (initial_amount, initial_amount)),
+					(coin1, (100000000, 105000000))
+				]
 			);
+			assert_ok!(StablePool::on_swap(&3u128, 0, 0, 1, 5000000u128, 0));
 
-			assert_ok!(StablePool::config_vtoken_auto_refresh(
-				RuntimeOrigin::root(),
-				VDOT,
-				Permill::from_percent(20)
-			));
+			assert_eq!(
+				bifrost_stable_asset::TokenRateCaches::<Test>::iter_prefix(0).collect::<Vec<(
+					AssetIdOf<Test>,
+					(AtLeast64BitUnsignedOf<Test>, AtLeast64BitUnsignedOf<Test>),
+				)>>(),
+				vec![
+					(coin0, (initial_amount, initial_amount)),
+					(coin1, (100000000, 110250000))
+				]
+			);
 			assert_ok!(StablePool::on_swap(&3u128, 0, 0, 1, 5000000u128, 0));
 			assert_eq!(
 				bifrost_stable_asset::TokenRateCaches::<Test>::iter_prefix(0).collect::<Vec<(
 					AssetIdOf<Test>,
 					(AtLeast64BitUnsignedOf<Test>, AtLeast64BitUnsignedOf<Test>),
 				)>>(),
-				vec![(coin0, (1, 1)), (coin1, (100000000, 120000000))]
+				vec![
+					(coin0, (initial_amount, initial_amount)),
+					(coin1, (100000000, 115762500))
+				]
 			);
-
-			assert_eq!(Tokens::free_balance(DOT, &3), 75000000u128 - BALANCE_OFF);
+			assert_ok!(StablePool::on_swap(&3u128, 0, 0, 1, 5000000u128, 0));
+			assert_ok!(StablePool::on_swap(&3u128, 0, 0, 1, 5000000u128, 0));
+			assert_eq!(
+				bifrost_stable_asset::TokenRateCaches::<Test>::iter_prefix(0).collect::<Vec<(
+					AssetIdOf<Test>,
+					(AtLeast64BitUnsignedOf<Test>, AtLeast64BitUnsignedOf<Test>),
+				)>>(),
+				vec![
+					(coin0, (initial_amount, initial_amount)),
+					(coin1, (100000000, 120000000))
+				]
+			);
+			assert_eq!(Tokens::free_balance(DOT, &3), 60000000u128 - BALANCE_OFF);
 		});
 }
 


### PR DESCRIPTION
When the rate change exceeds the hardtop, the exchange rate adjustment no longer fails directly, but is based on the hardtop adjustment.